### PR TITLE
Support Firefox for Mobile (Android).

### DIFF
--- a/content.css
+++ b/content.css
@@ -13,6 +13,11 @@
   margin-left: 4px;
 }
 
+.ubMobileAction {
+  font-size: 12px;
+  margin-left: 12px;
+}
+
 .ubImageAction {
   display: block;
   font-size: 10px;
@@ -70,4 +75,14 @@
 #ubBlockInput, #ubUnblockSelect {
   margin: 0 6px;
   width: 280px;
+}
+
+@media screen and (max-width: 400px) {
+  #ubBlockForm > button, #ubUnblockForm > button {
+    display: block;
+    margin: 0 auto;
+  }
+  #ubBlockInput, #ubUnblockSelect {
+    display: block;
+  }
 }

--- a/inspector.js
+++ b/inspector.js
@@ -214,7 +214,7 @@ const inspectEntry = elem => {
 
       if (info.id == 'Search.ForFirefoxMobileWebResult') {
         const parsed = new URL(pageUrl);
-        if (parsed && (parsed.pathname !== '/url')) {
+        if (!parsed || (parsed.pathname !== '/url')) {
           continue;
         }
         pageUrl = parsed.searchParams.get('q') || pageUrl;

--- a/inspector.js
+++ b/inspector.js
@@ -40,6 +40,26 @@ const ENTRY_INFO = [
     display:      'default'
   },
   {
+    id:           'Search.ModernMobileWebResult',
+    target:       'div#rso div.xpd',
+    targetDepth:  0,
+    pageLink:     '> div:first-child a',
+    pageLinkType: 'default',
+    actionParent: '> div:last-child',
+    actionClass:  'ubMobileAction',
+    display:      'default'
+  },
+  {
+    id:           'Search.ForFirefoxMobileWebResult',
+    target:       'div#main > div.xpd',
+    targetDepth:  0,
+    pageLink:     '> div > div:first-child > a',
+    pageLinkType: 'default',
+    actionParent: '> div',
+    actionClass:  'ubMobileAction',
+    display:      'default'
+  },
+  {
     id:           'Search.Image',
     target:       'div#iur > div.kno-ibrg > div > div.img-brk > div.birrg > div.rg_el.ivg-i > div.rg_meta.notranslate',
     targetDepth:  1,
@@ -190,6 +210,14 @@ const inspectEntry = elem => {
         }
       } else {
         actionParent = base;
+      }
+
+      if (info.id == 'Search.ForFirefoxMobileWebResult') {
+        const parsed = new URL(pageUrl);
+        if (parsed && (parsed.pathname !== '/url')) {
+          continue;
+        }
+        pageUrl = parsed.searchParams.get('q') || pageUrl;
       }
 
       if (info.id == 'Search.Image') {


### PR DESCRIPTION
Currently, users can install this extension into Firefox for Mobile (Android), but it doesn't works.
This PR adds support for such mobile search pages on Google.

Limitation : Image search is could not supported (because mobile image search page seems that it doesn't have links. Maybe controlled by JavaScript. Do you have any ideas to resolve this issue?).