### PR TITLE
Fix inspector rules for mobile search page

### DIFF
--- a/content.js
+++ b/content.js
@@ -116,6 +116,9 @@ class UBlacklist {
           .ubBlockedEntry .ubUnblockButton {
             display: none;
           }
+          .ubMobileAction {
+            display: none;
+          }
         `);
       }
     })();

--- a/inspector.js
+++ b/inspector.js
@@ -51,11 +51,11 @@ const ENTRY_INFO = [
   },
   {
     id:           'Search.ForFirefoxMobileWebResult',
-    target:       'div#main > div.xpd',
+    target:       'div#main div.xpd',
     targetDepth:  0,
-    pageLink:     '> div > div:first-child > a',
+    pageLink:     '> div:first-child > a',
     pageLinkType: 'default',
-    actionParent: '> div',
+    actionParent: '',
     actionClass:  'ubMobileAction',
     display:      'default'
   },

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "__MSG_extensionName__",
-  "version": "2.4.0",
+  "version": "2.5.0",
 
   "default_locale": "en",
   "description": "__MSG_extensionDescription__",


### PR DESCRIPTION
Google changed DOM structs of mobile search page, so I fixed inspector rules for it.
And, add 'display: none;' to ubMobileAction if hideBlockLinks is enabled in order to remove unnecessary space.