### PR TITLE
feat: Add path depth selector to provide easiest way for blocking user-generated contents

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -75,6 +75,10 @@
     "message": "Page URL",
     "description": "The label for the input that shows a page URL."
   },
+  "popup_pathDepth": {
+    "message": "Depth",
+    "description": "The label for the input that shows a path depth of rules to be added."
+  },
   "popup_addedRulesLabel": {
     "message": "Rules to be added",
     "description": "The label for the textarea that shows rules to be added."

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -57,6 +57,9 @@
   "popup_pageURLLabel": {
     "message": "ページの URL"
   },
+  "popup_pathDepth": {
+    "message": "階層"
+  },
   "popup_addedRulesLabel": {
     "message": "追加されるルール"
   },

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -57,6 +57,9 @@
   "popup_pageURLLabel": {
     "message": "URL страницы"
   },
+  "popup_pathDepth": {
+    "message": "глубина"
+  },
   "popup_addedRulesLabel": {
     "message": "Правила, которые будут добавлены"
   },

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -57,6 +57,9 @@
   "popup_pageURLLabel": {
     "message": "Page URL"
   },
+  "popup_pathDepth": {
+    "message": "Depth"
+  },
   "popup_addedRulesLabel": {
     "message": "Rules to be added"
   },

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -57,6 +57,9 @@
   "popup_pageURLLabel": {
     "message": "页面 URL"
   },
+  "popup_pathDepth": {
+    "message": "深度"
+  },
   "popup_addedRulesLabel": {
     "message": "要添加的规则"
   },

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -57,6 +57,9 @@
   "popup_pageURLLabel": {
     "message": "網頁 URL"
   },
+  "popup_pathDepth": {
+    "message": "深度"
+  },
   "popup_addedRulesLabel": {
     "message": "要加入的規則"
   },

--- a/src/scripts/blacklist.test.ts
+++ b/src/scripts/blacklist.test.ts
@@ -93,4 +93,20 @@ https://*.example.edu/`);
 @/edu/`,
   });
   expect(p123f).toBe(null);
+
+  b123.createPatch(new AltURL('http://www.example.com/foo/bar/baz'));
+  const p123g = b123.modifyPatchDepth(1);
+  expect(p123g?.rulesToAdd).toBe('*://www.example.com/foo/*');
+
+  const p123h = b123.modifyPatchDepth(2);
+  expect(p123h?.rulesToAdd).toBe('*://www.example.com/foo/bar/*');
+
+  const p123i = b123.modifyPatchDepth(3);
+  expect(p123i).toBe(null);
+
+  const p123j = b123.modifyPatchDepth(0);
+  expect(p123j?.rulesToAdd).toBe('*://www.example.com/*');
+
+  const p123k = b123.modifyPatchDepth(-1);
+  expect(p123k).toBe(null);
 });

--- a/src/scripts/blacklist.ts
+++ b/src/scripts/blacklist.ts
@@ -261,12 +261,11 @@ export class Blacklist {
     return this.patch as BlacklistPatch;
   }
 
-  modifyPatchDepth(urlString: string, unblock: boolean, depth: number): BlacklistPatch | null {
-    if (this.patch?.unblock) {
+  modifyPatchDepth(depth: number): BlacklistPatch | null {
+    if (!this.patch || this.patch.unblock || depth < 0) {
       return null;
     }
-    const url = new AltURL(urlString);
-    const newUrl = appendDepthToMatchPattern(url, unblock, depth);
+    const newUrl = appendDepthToMatchPattern(this.patch.url, false, depth);
     return this.modifyPatch({ rulesToAdd: newUrl });
   }
 

--- a/src/scripts/blacklist.ts
+++ b/src/scripts/blacklist.ts
@@ -102,6 +102,20 @@ function suggestMatchPattern(url: AltURL, unblock: boolean): string {
   }
 }
 
+function appendDepthToMatchPattern(url: AltURL, unblock: boolean, depth: number): string {
+  if (url.scheme === 'http' || url.scheme === 'https') {
+    return `${unblock ? '@' : ''}*://${url.host}${url.path
+      .split('/')
+      .slice(0, 1 + depth)
+      .join('/')}/*`;
+  } else {
+    return `${unblock ? '@' : ''}${url.scheme}://${url.host}${url.path
+      .split('/')
+      .slice(0, 1 + depth)
+      .join('/')}/*`;
+  }
+}
+
 export class Blacklist {
   private userPart: Part;
   private subscriptionParts: Part[];
@@ -245,6 +259,15 @@ export class Blacklist {
     }
     this.patch.rulesToAdd = patch.rulesToAdd;
     return this.patch as BlacklistPatch;
+  }
+
+  modifyPatchDepth(urlString: string, unblock: boolean, depth: number): BlacklistPatch | null {
+    if (this.patch?.unblock) {
+      return null;
+    }
+    const url = new AltURL(urlString);
+    const newUrl = appendDepthToMatchPattern(url, unblock, depth);
+    return this.modifyPatch({ rulesToAdd: newUrl });
   }
 
   applyPatch(): void {

--- a/src/scripts/block-form.ts
+++ b/src/scripts/block-form.ts
@@ -35,7 +35,7 @@ export class BlockForm {
               ${apis.i18n.getMessage('popup_pathDepth')}
             </label>
             <div class="control">
-              <input id="depth" class="input" type="number" value="0" min="0">
+              <input id="depth" class="input" type="number" value="0" min="0" max="0">
             </div>
           </div>
           <div class="field">
@@ -106,7 +106,6 @@ export class BlockForm {
     this.$('origin').textContent = `${url.scheme}://${url.host}`;
     this.$('details').open = false;
     this.$('url').value = url.toString();
-    this.$('depth').max = String((url.path.match(/\//g)?.length || 1) - 1);
 
     if (/^(https?|ftp)$/.test(url.scheme)) {
       this.blacklist = blacklist;
@@ -115,6 +114,15 @@ export class BlockForm {
 
       this.$('title').textContent = apis.i18n.getMessage(
         this.blacklistPatch.unblock ? 'popup_unblockSiteTitle' : 'popup_blockSiteTitle',
+      );
+      this.$('depth').readOnly = false;
+      this.$('depth').max = String(
+        this.blacklistPatch.unblock
+          ? 0
+          : (url.path
+              .split(/[?#]/)
+              .shift()
+              ?.match(/\//g)?.length || 1) - 1,
       );
       this.$('added').readOnly = false;
       this.$('added').value = this.blacklistPatch.rulesToAdd;
@@ -129,6 +137,8 @@ export class BlockForm {
       this.onBlocked = null;
 
       this.$('title').textContent = apis.i18n.getMessage('popup_blockSiteTitle');
+      this.$('depth').readOnly = true;
+      this.$('depth').value = '0';
       this.$('added').readOnly = true;
       this.$('added').value = '';
       this.$('removed').value = '';

--- a/src/scripts/block-form.ts
+++ b/src/scripts/block-form.ts
@@ -31,6 +31,14 @@ export class BlockForm {
             </div>
           </div>
           <div class="field">
+            <label class="label" for="depth">
+              Depth
+            </label>
+            <div class="control">
+              <input id="depth" class="input" type="number" value="0" min="0">
+            </div>
+          </div>
+          <div class="field">
             <label class="label" for="added">
               ${apis.i18n.getMessage('popup_addedRulesLabel')}
             </label>
@@ -72,6 +80,15 @@ export class BlockForm {
         this.blacklistPatch = modifiedPatch;
       }
       this.$('update').disabled = !modifiedPatch;
+    });
+    this.$('depth').addEventListener('input', () => {
+      const depth = parseInt(this.$('depth').value, 10);
+      const modifiedPatch = this.blacklist!.modifyPatchDepth(this.$('url').value, false, depth);
+      if (modifiedPatch) {
+        this.blacklistPatch = modifiedPatch;
+        this.$('added').value = modifiedPatch.rulesToAdd;
+        this.$('update').disabled = false;
+      }
     });
     this.$('cancel').addEventListener('click', () => {
       close();
@@ -125,6 +142,7 @@ export class BlockForm {
   private $(id: 'url'): HTMLInputElement;
   private $(id: 'added'): HTMLTextAreaElement;
   private $(id: 'addedHelper'): HTMLParagraphElement;
+  private $(id: 'depth'): HTMLInputElement;
   private $(id: 'removed'): HTMLTextAreaElement;
   private $(id: 'cancel'): HTMLButtonElement;
   private $(id: 'update'): HTMLButtonElement;

--- a/src/scripts/block-form.ts
+++ b/src/scripts/block-form.ts
@@ -32,7 +32,7 @@ export class BlockForm {
           </div>
           <div class="field">
             <label class="label" for="depth">
-              Depth
+              ${apis.i18n.getMessage('popup_pathDepth')}
             </label>
             <div class="control">
               <input id="depth" class="input" type="number" value="0" min="0">

--- a/src/scripts/block-form.ts
+++ b/src/scripts/block-form.ts
@@ -106,6 +106,7 @@ export class BlockForm {
     this.$('origin').textContent = `${url.scheme}://${url.host}`;
     this.$('details').open = false;
     this.$('url').value = url.toString();
+    this.$('depth').max = String((url.path.match(/\//g)?.length || 1) - 1);
 
     if (/^(https?|ftp)$/.test(url.scheme)) {
       this.blacklist = blacklist;

--- a/src/scripts/block-form.ts
+++ b/src/scripts/block-form.ts
@@ -83,7 +83,7 @@ export class BlockForm {
     });
     this.$('depth').addEventListener('input', () => {
       const depth = parseInt(this.$('depth').value, 10);
-      const modifiedPatch = this.blacklist!.modifyPatchDepth(this.$('url').value, false, depth);
+      const modifiedPatch = this.blacklist!.modifyPatchDepth(depth);
       if (modifiedPatch) {
         this.blacklistPatch = modifiedPatch;
         this.$('added').value = modifiedPatch.rulesToAdd;


### PR DESCRIPTION
I'm tired that low quality contents created by users appear in search results  every day. I want to block these but not the whole platform such as Twitter, Medium and Qiita. And I need a way to easily specify and block user-generated content which is described the name of author in subdirectories.


<img width="200" alt="screenshot 1" src="https://user-images.githubusercontent.com/2971112/73351758-0c4b1000-42d3-11ea-9fb8-378e97d011d0.png"> <img width="200" alt="screenshot 2" src="https://user-images.githubusercontent.com/2971112/73351759-0c4b1000-42d3-11ea-881c-a88c7fb11b11.png"> <img width="195" alt="screenshot 3" src="https://user-images.githubusercontent.com/2971112/73351760-0ce3a680-42d3-11ea-9165-d1e616c3c3d2.png">
