### PR TITLE
Add ecosia.ts search-engine

### DIFF
--- a/src/_locales/en/messages.json.ts
+++ b/src/_locales/en/messages.json.ts
@@ -257,7 +257,7 @@ export default exportMessages({
 
   // The localized name of DuckDuckGo
   searchEngines_duckduckgoName: 'DuckDuckGo',
-  
+
   // The localized name of Ecosia
   searchEngines_ecosiaName: 'Ecosia',
 

--- a/src/_locales/en/messages.json.ts
+++ b/src/_locales/en/messages.json.ts
@@ -257,6 +257,9 @@ export default exportMessages({
 
   // The localized name of DuckDuckGo
   searchEngines_duckduckgoName: 'DuckDuckGo',
+  
+  // The localized name of Ecosia
+  searchEngines_ecosiaName: 'Ecosia',
 
   // The localized name of Startpage.com
   searchEngines_startpageName: 'Startpage.com',

--- a/src/locale.d.ts
+++ b/src/locale.d.ts
@@ -82,6 +82,7 @@ export type MessageName =
   | 'clouds_dropboxSyncDescription'
   | 'clouds_dropboxSyncTurnedOn'
   | 'searchEngines_duckduckgoName'
+  | 'searchEngines_ecosiaName'
   | 'searchEngines_startpageName';
 
 export type MessageName1 = 'error' | 'content_multipleSitesBlocked' | 'options_blacklistExample';

--- a/src/scripts/search-engines/ecosia.ts
+++ b/src/scripts/search-engines/ecosia.ts
@@ -15,18 +15,8 @@ const ubSelectors = {
   button: '.ub-link-button',
 };
 
-function adjustButtons(element: HTMLElement): void {
-  for (const button of element.querySelectorAll<HTMLElement>(ubSelectors.button)) {
-    button.classList.add('msg__all');
-  }
-}
-
 export const ecosia: SearchEngine = {
-  matches: [
-    '*://www.ecosia.org/',
-    '*://www.ecosia.org//',
-    '*://www.ecosia.org/search?*'
-  ],
+  matches: [ '*://www.ecosia.org/search?*' ],
   messageNames: {
     name: 'searchEngines_ecosiaName',
   },
@@ -45,7 +35,6 @@ export const ecosia: SearchEngine = {
           message.insertBefore(control, message.firstChild);
           return control;
         },
-        adjustControl: adjustButtons,
       },
     ],
     entryHandlers: [
@@ -53,7 +42,6 @@ export const ecosia: SearchEngine = {
         getEntry: getEntry(pageSelectors.entry),
         getURL: getURL(pageSelectors.url),
         createAction: createAction(ubSelectors.action),
-        adjustEntry: adjustButtons,
       },
     ],
     getAddedElements: getAddedElements(pageSelectors.results),

--- a/src/scripts/search-engines/ecosia.ts
+++ b/src/scripts/search-engines/ecosia.ts
@@ -16,7 +16,7 @@ const ubSelectors = {
 };
 
 export const ecosia: SearchEngine = {
-  matches: [ '*://www.ecosia.org/search?*' ],
+  matches: ['*://www.ecosia.org/search?*'],
   messageNames: {
     name: 'searchEngines_ecosiaName',
   },
@@ -41,7 +41,7 @@ export const ecosia: SearchEngine = {
       {
         getEntry: getEntry(pageSelectors.entry),
         getURL: getURL(pageSelectors.url),
-        createAction: createAction(ubSelectors.action),
+        createAction: createAction(ubSelectors.action, ''),
       },
     ],
     getAddedElements: getAddedElements(pageSelectors.results),

--- a/src/scripts/search-engines/ecosia.ts
+++ b/src/scripts/search-engines/ecosia.ts
@@ -1,0 +1,61 @@
+import { SearchEngine } from '../types';
+import { createAction, getAddedElements, getEntry, getURL } from './helpers';
+import ecosiaStyle from '!!raw-loader!extract-loader!css-loader!sass-loader!../../styles/search-engines/ecosia.scss';
+
+const pageSelectors = {
+  results: '.mainline-results .result',
+  entry: '.mainline-results .result',
+  url: '.mainline-results .result a',
+  message: '.mainline-top',
+};
+
+const ubSelectors = {
+  action: 'ub-web-general-action',
+  control: 'ub-web-control msg',
+  button: '.ub-link-button',
+};
+
+function adjustButtons(element: HTMLElement): void {
+  for (const button of element.querySelectorAll<HTMLElement>(ubSelectors.button)) {
+    button.classList.add('msg__all');
+  }
+}
+
+export const ecosia: SearchEngine = {
+  matches: [
+    '*://www.ecosia.org/',
+    '*://www.ecosia.org//',
+    '*://www.ecosia.org/search?*'
+  ],
+  messageNames: {
+    name: 'searchEngines_ecosiaName',
+  },
+  style: ecosiaStyle,
+
+  getHandlers: () => ({
+    controlHandlers: [
+      {
+        createControl: (): HTMLElement | null => {
+          const message = document.querySelector(pageSelectors.message);
+          if (!message) {
+            return null;
+          }
+          const control = document.createElement('div');
+          control.className = ubSelectors.control;
+          message.insertBefore(control, message.firstChild);
+          return control;
+        },
+        adjustControl: adjustButtons,
+      },
+    ],
+    entryHandlers: [
+      {
+        getEntry: getEntry(pageSelectors.entry),
+        getURL: getURL(pageSelectors.url),
+        createAction: createAction(ubSelectors.action),
+        adjustEntry: adjustButtons,
+      },
+    ],
+    getAddedElements: getAddedElements(pageSelectors.results),
+  }),
+};

--- a/src/scripts/supported-search-engines.ts
+++ b/src/scripts/supported-search-engines.ts
@@ -1,3 +1,4 @@
+import { ecosia } from './search-engines/ecosia';
 import { duckduckgo } from './search-engines/duckduckgo';
 import { google } from './search-engines/google';
 import { startpage } from './search-engines/startpage';
@@ -7,4 +8,5 @@ export const supportedSearchEngines: SearchEngines = {
   google,
   duckduckgo,
   startpage,
+  ecosia,
 };

--- a/src/scripts/types.ts
+++ b/src/scripts/types.ts
@@ -50,7 +50,7 @@ export type CloudToken = {
 // #endregion Clouds
 
 // #region SearchEngines
-export type SearchEngineId = 'google' | 'duckduckgo' | 'startpage';
+export type SearchEngineId = 'google' | 'duckduckgo' | 'startpage' | 'ecosia';
 
 export type ControlHandler = {
   createControl(): HTMLElement | null;

--- a/src/styles/search-engines/ecosia.scss
+++ b/src/styles/search-engines/ecosia.scss
@@ -1,0 +1,11 @@
+.ub-link-button.msg__all {
+  display: inline;
+  font-size: 13px;
+  color: #00644d;
+}
+
+.ub-control.msg {
+  font-size: 13px;
+  text-align: right;
+  padding-right: 1em;
+}

--- a/src/styles/search-engines/ecosia.scss
+++ b/src/styles/search-engines/ecosia.scss
@@ -1,4 +1,4 @@
-.ub-link-button.msg__all {
+.ub-link-button {
   display: inline;
   font-size: 13px;
   color: #00644d;


### PR DESCRIPTION
This PR adds ecosia search engine support.

Demo:
![ecosia-demo](https://user-images.githubusercontent.com/6493307/97082599-32f06a00-160b-11eb-83ce-1e7b2aad423a.gif)

Note:
There is a minor spacing issue (wasted screen real estate) when there are multiple blocked results and these results come first on the page. This behaviour seems consistent with the Google and DuckDuckGo behaviour.
![Screenshot_2020-10-24 Ecosia - the search engine that plants trees](https://user-images.githubusercontent.com/6493307/97082648-911d4d00-160b-11eb-89a5-a6c938c97ae9.png)

Fixes #62 