### PR TITLE
feat(subscription): skip permission requests for another CDN

### DIFF
--- a/src/scripts/options/subscription-section.tsx
+++ b/src/scripts/options/subscription-section.tsx
@@ -50,7 +50,11 @@ import { FromNow } from './from-now';
 import { useOptionsContext } from './options-context';
 import { SetIntervalItem } from './set-interval-item';
 
-const PERMISSION_PASSLIST = ['*://*.githubusercontent.com/*'];
+const PERMISSION_PASSLIST = [
+  '*://*.githubusercontent.com/*',
+  // A third-party CDN service supporting GitHub, GitLab and BitBucket
+  '*://cdn.statically.io/*',
+];
 
 async function requestPermission(urls: readonly string[]): Promise<boolean> {
   const origins: string[] = [];


### PR DESCRIPTION
This improves the workaround for Firefox on Android to support GitLab
and BitBucket.

Services considered:

* https://raw.githack.com/
  * supports GitHub, GitLab, BitBucket and SourceHut
  * uses multiple domains (rawcdn.githack.com, glcdn.githack.com, bbcdn.githack.com)
  * apparently SourceHut support is broken (cannot parse URL)
* https://rawgit.org/
  * supports GitHub, GitLab and BitBucket
  * uses multiple domains (ghcdn.rawgit.org, glcdn.rawgit.org, bbcdn.rawgit.org)
  * apparently GitLab and BitBucket support are broken (404)
* https://statically.io/
  * suuports GitHub, GitLab and BitBucket
  * uses single domain (cdn.statically.io)

I pick the last one to make `PERMISSION_PASSLIST` shorter.

See #117