### PR TITLE
chore: fix a dialog UI issue on iPhone

### DIFF
--- a/src/scripts/components/dialog.tsx
+++ b/src/scripts/components/dialog.tsx
@@ -206,7 +206,9 @@ export const EmbeddedDialog = forwardRef(
           outline: 'none',
           padding: '1.5em',
           // #if SAFARI
-          minWidth: width,
+          [`@media (min-device-width: ${width})`]: {
+            minWidth: width,
+          },
           // #else
           width,
           // #endif


### PR DESCRIPTION
I found an issue about dialog on iPhone. The dialog view width does not fill his container.

![issue-screenshot](https://user-images.githubusercontent.com/4635725/137593903-dee29772-5329-4514-a31c-3178a38c184b.PNG)

I try to fix it with this commit. 
After my test, it seems to work fine on both iPhone and iPad.

![resolved-screenshot](https://user-images.githubusercontent.com/4635725/137594094-e8d784de-2a46-4eb5-812a-548fa815c6a8.png)


