### PR TITLE
Add Yahoo! JAPAN as search engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This extension is available in the below search engines.
 | Qwant (iOS)      | :heavy_check_mark: | :heavy_check_mark: | \*1                | :heavy_check_mark: |
 | Startpage        | :heavy_check_mark: |                    | :heavy_check_mark: | :heavy_check_mark: |
 | Startpage (iOS)  | :heavy_check_mark: |                    | :heavy_check_mark: | :heavy_check_mark: |
+| Yahoo! JAPAN     | :heavy_check_mark: |                    |                    |                    |
 
 \*1 Works only if you turn off "Always play videos on Qwant.com"
 

--- a/src/common/locales.ts
+++ b/src/common/locales.ts
@@ -127,7 +127,8 @@ export type MessageName =
   | 'searchEngines_duckduckgoName'
   | 'searchEngines_ecosiaName'
   | 'searchEngines_qwantName'
-  | 'searchEngines_startpageName';
+  | 'searchEngines_startpageName'
+  | 'searchEngines_yahooJapanName';
 
 export type MessageName1 =
   | 'error'

--- a/src/common/search-engines.ts
+++ b/src/common/search-engines.ts
@@ -1,5 +1,6 @@
 import { MessageName0 } from './locales';
 
+// TODO: Add 'yahooJapan'
 export type SearchEngineId = 'google' | 'bing' | 'duckduckgo' | 'ecosia' | 'qwant' | 'startpage';
 
 export type SearchEngine = {
@@ -302,4 +303,5 @@ export const SEARCH_ENGINES: Readonly<Record<SearchEngineId, Readonly<SearchEngi
       name: 'searchEngines_startpageName',
     },
   },
+  // TODO: Add yahooJapan
 };

--- a/src/common/search-engines.ts
+++ b/src/common/search-engines.ts
@@ -1,7 +1,13 @@
 import { MessageName0 } from './locales';
 
-// TODO: Add 'yahooJapan'
-export type SearchEngineId = 'google' | 'bing' | 'duckduckgo' | 'ecosia' | 'qwant' | 'startpage';
+export type SearchEngineId =
+  | 'google'
+  | 'bing'
+  | 'duckduckgo'
+  | 'ecosia'
+  | 'qwant'
+  | 'startpage'
+  | 'yahooJapan';
 
 export type SearchEngine = {
   contentScripts: {
@@ -303,5 +309,15 @@ export const SEARCH_ENGINES: Readonly<Record<SearchEngineId, Readonly<SearchEngi
       name: 'searchEngines_startpageName',
     },
   },
-  // TODO: Add yahooJapan
+  yahooJapan: {
+    contentScripts: [
+      {
+        matches: ['https://search.yahoo.co.jp/search?*'],
+        runAt: 'document_idle',
+      },
+    ],
+    messageNames: {
+      name: 'searchEngines_yahooJapanName',
+    },
+  },
 };

--- a/src/locales/en.json.ts
+++ b/src/locales/en.json.ts
@@ -401,4 +401,7 @@ exportAsMessages('_locales/en/messages.json', {
 
   // The localized name of Startpage.
   searchEngines_startpageName: 'Startpage.com',
+
+  // The localized name of Yahoo! JAPAN.
+  searchEngines_yahooJapanName: 'Yahoo! JAPAN',
 });

--- a/src/scripts/search-engines.ts
+++ b/src/scripts/search-engines.ts
@@ -4,6 +4,7 @@ import { ecosia } from './search-engines/ecosia';
 import { google } from './search-engines/google';
 import { qwant } from './search-engines/qwant';
 import { startpage } from './search-engines/startpage';
+import { yahooJapan } from './search-engines/yahoo-japan';
 import { SearchEngine, SearchEngineId } from './types';
 
 export const SEARCH_ENGINES: Readonly<Record<SearchEngineId, Readonly<SearchEngine>>> = {
@@ -13,5 +14,5 @@ export const SEARCH_ENGINES: Readonly<Record<SearchEngineId, Readonly<SearchEngi
   ecosia,
   qwant,
   startpage,
-  // TODO: Add yahooJapan
+  yahooJapan,
 };

--- a/src/scripts/search-engines.ts
+++ b/src/scripts/search-engines.ts
@@ -13,4 +13,5 @@ export const SEARCH_ENGINES: Readonly<Record<SearchEngineId, Readonly<SearchEngi
   ecosia,
   qwant,
   startpage,
+  // TODO: Add yahooJapan
 };

--- a/src/scripts/search-engines/yahoo-japan-desktop.ts
+++ b/src/scripts/search-engines/yahoo-japan-desktop.ts
@@ -18,6 +18,7 @@ const webHandler = handleSerp({
     {
       target: '.Hits__item',
       style: {
+        color: '#666',
         marginLeft: '8px',
       },
     },

--- a/src/scripts/search-engines/yahoo-japan-desktop.ts
+++ b/src/scripts/search-engines/yahoo-japan-desktop.ts
@@ -1,0 +1,46 @@
+import type { SerpHandler } from '../types';
+import { handleSerp } from './helpers';
+
+const webHandler = handleSerp({
+  globalStyle: {
+    '[data-ub-blocked="visible"]': {
+      backgroundColor: 'var(--ub-block-color, rgba(255, 192, 192, 0.5))',
+    },
+    '.ub-button': {
+      color: 'var(--ub-link-color, var(--color-link, #000d99))',
+      textDecoration: 'underline',
+    },
+    '.ub-button:hover': {
+      color: '#cc3434',
+    },
+  },
+  controlHandlers: [
+    {
+      target: '.Hits__item',
+      style: {
+        marginLeft: '8px',
+      },
+    },
+  ],
+  entryHandlers: [
+    {
+      target: '.sw-CardBase',
+      url: '.sw-Card__titleInner',
+      title: '.sw-Card__titleMain',
+      actionTarget: '.sw-Card__floatContainer',
+      actionStyle: {
+        fontSize: '1.4rem',
+        lineHeight: 1.4,
+      },
+    },
+  ],
+});
+
+const handlers: Readonly<Record<string, SerpHandler | undefined>> = {
+  // Web
+  '/search': webHandler,
+};
+
+export const getDesktopSerpHandler = (path: string): SerpHandler | null => {
+  return handlers[path] ?? null;
+};

--- a/src/scripts/search-engines/yahoo-japan-mobile.ts
+++ b/src/scripts/search-engines/yahoo-japan-mobile.ts
@@ -1,0 +1,39 @@
+import type { SerpHandler } from '../types';
+import { handleSerp } from './helpers';
+
+const webHandler = handleSerp({
+  globalStyle: {
+    '[data-ub-blocked="visible"]': {
+      backgroundColor: 'var(--ub-block-color, rgba(255, 192, 192, 0.5))',
+    },
+    '.ub-button': {
+      color: 'var(--ub-link-color, var(--color-link, #000d99))',
+    },
+  },
+  controlHandlers: [
+    {
+      target: '.SearchTool',
+    },
+  ],
+  entryHandlers: [
+    {
+      target: '.sw-CardBase',
+      url: '.sw-Card__space',
+      title: '.sw-Card__titleMain',
+      actionTarget: '.sw-Card__floatContainer',
+      actionStyle: {
+        fontSize: '12px',
+        lineHeight: 1.6,
+      },
+    },
+  ],
+});
+
+const handlers: Readonly<Record<string, SerpHandler | undefined>> = {
+  // Web
+  '/search': webHandler,
+};
+
+export const getMobileSerpHandler = (path: string): SerpHandler | null => {
+  return handlers[path] ?? null;
+};

--- a/src/scripts/search-engines/yahoo-japan-mobile.ts
+++ b/src/scripts/search-engines/yahoo-japan-mobile.ts
@@ -13,6 +13,9 @@ const webHandler = handleSerp({
   controlHandlers: [
     {
       target: '.SearchTool',
+      style: {
+        color: '#666',
+      },
     },
   ],
   entryHandlers: [

--- a/src/scripts/search-engines/yahoo-japan.ts
+++ b/src/scripts/search-engines/yahoo-japan.ts
@@ -1,0 +1,15 @@
+import mobile from 'is-mobile';
+import { SEARCH_ENGINES } from '../../common/search-engines';
+import type { SearchEngine } from '../types';
+import { getDesktopSerpHandler } from './yahoo-japan-desktop';
+import { getMobileSerpHandler } from './yahoo-japan-mobile';
+
+export const yahooJapan: Readonly<SearchEngine> = {
+  ...SEARCH_ENGINES.yahooJapan,
+  getSerpHandler() {
+    const { pathname } = new URL(window.location.href);
+    return mobile({ tablet: false })
+      ? getMobileSerpHandler(pathname)
+      : getDesktopSerpHandler(pathname);
+  },
+};


### PR DESCRIPTION
close #235

This PR adds [Yahoo! JAPAN](https://search.yahoo.co.jp/) as a search engine. For now, only web searches are supported.

## Screenshots

|Desktop|Mobile|
|---|---|
|<img width="606" alt="スクリーンショット 2022-05-21 0 56 22" src="https://user-images.githubusercontent.com/20086673/169566558-683f8aae-76c1-4673-9d3e-7ecfedba5f94.png">|![search yahoo co jp_search_p=%E6%97%A5%E6%9C%AC%E8%AA%9E x=wrt aq=-1 ai=fad6c68d-caff-49b1-8d6c-5abde29add38 ts=3544 ei=UTF-8(iPhone X) (2)](https://user-images.githubusercontent.com/20086673/169566383-93dc6075-9367-44d4-8515-cf7c162557ec.png)|
