### PR TITLE
Initial support for brave search engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This extension is available in the below search engines.
 | ------------ | ------------------ | ------------------ | ------------------ | ------------------ |
 | Google       | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | Bing         | \*1                | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| Brave        | :heavy_check_mark: |                    |                    |                    |
+| Brave        | :heavy_check_mark: | :heavy_check_mark: |                    |                    |
 | DuckDuckGo   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | Ecosia       | :heavy_check_mark: |                    |                    |                    |
 | Qwant        | :heavy_check_mark: | :heavy_check_mark: | \*2                | :heavy_check_mark: |

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This extension is available in the below search engines.
 | ------------ | ------------------ | ------------------ | ------------------ | ------------------ |
 | Google       | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | Bing         | \*1                | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| Brave        | :heavy_check_mark: | :heavy_check_mark: |                    | :heavy_check_mark: |
+| Brave        | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | DuckDuckGo   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | Ecosia       | :heavy_check_mark: |                    |                    |                    |
 | Qwant        | :heavy_check_mark: | :heavy_check_mark: | \*2                | :heavy_check_mark: |

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This extension is available in the below search engines.
 | ------------ | ------------------ | ------------------ | ------------------ | ------------------ |
 | Google       | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | Bing         | \*1                | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
-| Brave        | :heavy_check_mark: | :heavy_check_mark: |                    |                    |
+| Brave        | :heavy_check_mark: | :heavy_check_mark: |                    | :heavy_check_mark: |
 | DuckDuckGo   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | Ecosia       | :heavy_check_mark: |                    |                    |                    |
 | Qwant        | :heavy_check_mark: | :heavy_check_mark: | \*2                | :heavy_check_mark: |

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This extension is available in the below search engines.
 | ------------ | ------------------ | ------------------ | ------------------ | ------------------ |
 | Google       | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | Bing         | \*1                | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
+| Brave        | :heavy_check_mark: |                    |                    |                    |
 | DuckDuckGo   | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | Ecosia       | :heavy_check_mark: |                    |                    |                    |
 | Qwant        | :heavy_check_mark: | :heavy_check_mark: | \*2                | :heavy_check_mark: |

--- a/src/common/locales.ts
+++ b/src/common/locales.ts
@@ -124,6 +124,7 @@ export type MessageName =
   | 'clouds_dropboxSyncTurnedOn'
   | 'searchEngines_googleName'
   | 'searchEngines_bingName'
+  | 'searchEngines_braveName'
   | 'searchEngines_duckduckgoName'
   | 'searchEngines_ecosiaName'
   | 'searchEngines_qwantName'

--- a/src/common/search-engines.ts
+++ b/src/common/search-engines.ts
@@ -3,6 +3,7 @@ import { MessageName0 } from './locales';
 export type SearchEngineId =
   | 'google'
   | 'bing'
+  | 'brave'
   | 'duckduckgo'
   | 'ecosia'
   | 'qwant'
@@ -252,6 +253,17 @@ export const SEARCH_ENGINES: Readonly<Record<SearchEngineId, Readonly<SearchEngi
     ],
     messageNames: {
       name: 'searchEngines_bingName',
+    },
+  },
+  brave: {
+    contentScripts: [
+      {
+        matches: ['https://search.brave.com/search?*'],
+        runAt: 'document_start',
+      },
+    ],
+    messageNames: {
+      name: 'searchEngines_braveName',
     },
   },
   duckduckgo: {

--- a/src/common/search-engines.ts
+++ b/src/common/search-engines.ts
@@ -262,6 +262,7 @@ export const SEARCH_ENGINES: Readonly<Record<SearchEngineId, Readonly<SearchEngi
           'https://search.brave.com/search?*',
           'https://search.brave.com/images?*',
           'https://search.brave.com/news?*',
+          'https://search.brave.com/videos?*',
         ],
         runAt: 'document_start',
       },

--- a/src/common/search-engines.ts
+++ b/src/common/search-engines.ts
@@ -258,7 +258,11 @@ export const SEARCH_ENGINES: Readonly<Record<SearchEngineId, Readonly<SearchEngi
   brave: {
     contentScripts: [
       {
-        matches: ['https://search.brave.com/search?*', 'https://search.brave.com/images?*'],
+        matches: [
+          'https://search.brave.com/search?*',
+          'https://search.brave.com/images?*',
+          'https://search.brave.com/news?*',
+        ],
         runAt: 'document_start',
       },
     ],

--- a/src/common/search-engines.ts
+++ b/src/common/search-engines.ts
@@ -258,7 +258,7 @@ export const SEARCH_ENGINES: Readonly<Record<SearchEngineId, Readonly<SearchEngi
   brave: {
     contentScripts: [
       {
-        matches: ['https://search.brave.com/search?*'],
+        matches: ['https://search.brave.com/search?*', 'https://search.brave.com/images?*'],
         runAt: 'document_start',
       },
     ],

--- a/src/locales/de.json.ts
+++ b/src/locales/de.json.ts
@@ -139,6 +139,7 @@ exportAsMessages('_locales/de/messages.json', {
   clouds_dropboxSyncTurnedOn: 'Mit Dropbox synchronisiert',
   searchEngines_googleName: 'Google',
   searchEngines_bingName: 'Bing',
+  searchEngines_braveName: 'Brave',
   searchEngines_duckduckgoName: 'DuckDuckGo',
   searchEngines_ecosiaName: 'Ecosia',
   searchEngines_qwantName: 'Qwant',

--- a/src/locales/en.json.ts
+++ b/src/locales/en.json.ts
@@ -389,6 +389,8 @@ exportAsMessages('_locales/en/messages.json', {
 
   // The localized name of Bing.
   searchEngines_bingName: 'Bing',
+  // The localized name of Brave
+  searchEngines_braveName: 'Brave',
 
   // The localized name of DuckDuckGo.
   searchEngines_duckduckgoName: 'DuckDuckGo',

--- a/src/locales/es.json.ts
+++ b/src/locales/es.json.ts
@@ -248,6 +248,8 @@ exportAsMessages('_locales/es/messages.json', {
 
   searchEngines_bingName: 'Bing',
 
+  searchEngines_braveName: 'Brave',
+
   searchEngines_duckduckgoName: 'DuckDuckGo',
 
   searchEngines_ecosiaName: 'Ecosia',

--- a/src/locales/ru.json.ts
+++ b/src/locales/ru.json.ts
@@ -136,6 +136,7 @@ exportAsMessages('_locales/ru/messages.json', {
   clouds_dropboxSyncTurnedOn: 'Синхронизирован с Dropbox',
   searchEngines_googleName: 'Google',
   searchEngines_bingName: 'Bing',
+  searchEngines_braveName: 'Brave',
   searchEngines_duckduckgoName: 'DuckDuckGo',
   searchEngines_ecosiaName: 'Ecosia',
   searchEngines_qwantName: 'Qwant',

--- a/src/locales/uk.json.ts
+++ b/src/locales/uk.json.ts
@@ -122,6 +122,7 @@ exportAsMessages('_locales/uk/messages.json', {
   clouds_dropboxSyncTurnedOn: 'Синхронізовано з Dropbox',
   searchEngines_googleName: 'Google',
   searchEngines_bingName: 'Bing',
+  searchEngines_braveName: 'Brave',
   searchEngines_duckduckgoName: 'DuckDuckGo',
   searchEngines_ecosiaName: 'Ecosia',
   searchEngines_qwantName: 'Qwant',

--- a/src/locales/zh-cn.json.ts
+++ b/src/locales/zh-cn.json.ts
@@ -130,6 +130,7 @@ exportAsMessages('_locales/zh_CN/messages.json', {
   clouds_dropboxSyncTurnedOn: '已使用 Dropbox 同步',
   searchEngines_googleName: '谷歌',
   searchEngines_bingName: '必应',
+  searchEngines_braveName: 'Brave',
   searchEngines_duckduckgoName: 'DuckDuckGo',
   searchEngines_ecosiaName: 'Ecosia',
   searchEngines_qwantName: 'Qwant',

--- a/src/scripts/search-engines.ts
+++ b/src/scripts/search-engines.ts
@@ -1,4 +1,5 @@
 import { bing } from './search-engines/bing';
+import { brave } from './search-engines/brave';
 import { duckduckgo } from './search-engines/duckduckgo';
 import { ecosia } from './search-engines/ecosia';
 import { google } from './search-engines/google';
@@ -11,6 +12,7 @@ import { SearchEngine, SearchEngineId } from './types';
 export const SEARCH_ENGINES: Readonly<Record<SearchEngineId, Readonly<SearchEngine>>> = {
   google,
   bing,
+  brave,
   duckduckgo,
   ecosia,
   qwant,

--- a/src/scripts/search-engines/brave.ts
+++ b/src/scripts/search-engines/brave.ts
@@ -57,6 +57,13 @@ function getSerpHandler(): SerpHandler {
           fontSize: 'var(--text-sm-2)',
         },
       },
+      // News
+      {
+        target: '#results.section > [data-macro="news"]',
+        url: '.result-header',
+        title: '.snippet-title',
+        actionTarget: '.news-header',
+      },
     ],
   });
 }

--- a/src/scripts/search-engines/brave.ts
+++ b/src/scripts/search-engines/brave.ts
@@ -1,6 +1,6 @@
 import { SEARCH_ENGINES } from '../../common/search-engines';
 import { SearchEngine, SerpHandler } from '../types';
-import { handleSerp } from './helpers';
+import { getDialogThemeFromBody, handleSerp } from './helpers';
 
 function getSerpHandler(): SerpHandler {
   return handleSerp({
@@ -40,7 +40,7 @@ function getSerpHandler(): SerpHandler {
     entryHandlers: [
       // Web
       {
-        target: '#results.section > .fdb',
+        target: '#results.section > .snippet',
         url: '.result-header',
         title: '.snippet-title',
         actionTarget: '.result-header',
@@ -78,6 +78,7 @@ function getSerpHandler(): SerpHandler {
         actionTarget: '.news-header',
       },
     ],
+    getDialogTheme: getDialogThemeFromBody(),
   });
 }
 

--- a/src/scripts/search-engines/brave.ts
+++ b/src/scripts/search-engines/brave.ts
@@ -17,6 +17,9 @@ function getSerpHandler(): SerpHandler {
       'div[id^=img-]': {
         marginBottom: '80px !important',
       },
+      'div[id^=img-][data-ub-blocked="visible"]': {
+        marginRight: '80px !important',
+      },
       '[data-ub-blocked="visible"] > .img-url': {
         backgroundColor: 'var(--ub-block-color, rgba(255, 192, 192, 0.5)) !important',
       },

--- a/src/scripts/search-engines/brave.ts
+++ b/src/scripts/search-engines/brave.ts
@@ -23,6 +23,9 @@ function getSerpHandler(): SerpHandler {
       '[data-ub-blocked="visible"] > .img-url': {
         backgroundColor: 'var(--ub-block-color, rgba(255, 192, 192, 0.5)) !important',
       },
+      '.center-horizontally': {
+        flexWrap: 'wrap',
+      },
     },
     controlHandlers: [
       {
@@ -55,6 +58,16 @@ function getSerpHandler(): SerpHandler {
           position: 'relative',
           top: '30px',
           fontSize: 'var(--text-sm-2)',
+        },
+      },
+      // Videos
+      {
+        target: '#results.section > .card',
+        url: 'a',
+        title: '.card-body > .title',
+        actionTarget: '.card-body > div',
+        actionStyle: {
+          fontSize: 'var(--text-sm)',
         },
       },
       // News

--- a/src/scripts/search-engines/brave.ts
+++ b/src/scripts/search-engines/brave.ts
@@ -17,9 +17,6 @@ function getSerpHandler(): SerpHandler {
       'div[id^=img-]': {
         marginBottom: '80px !important',
       },
-      'div[id^=img-][data-ub-blocked="visible"]': {
-        marginRight: '80px !important',
-      },
       '[data-ub-blocked="visible"] > .img-url': {
         backgroundColor: 'var(--ub-block-color, rgba(255, 192, 192, 0.5)) !important',
       },

--- a/src/scripts/search-engines/brave.ts
+++ b/src/scripts/search-engines/brave.ts
@@ -14,6 +14,15 @@ function getSerpHandler(): SerpHandler {
       '.ub-button:hover': {
         textDecoration: 'underline',
       },
+      'div[id^=img-]': {
+        marginBottom: '80px !important',
+      },
+      'div[id^=img-][data-ub-blocked="visible"]': {
+        marginRight: '80px !important',
+      },
+      '[data-ub-blocked="visible"] > .img-url': {
+        backgroundColor: 'var(--ub-block-color, rgba(255, 192, 192, 0.5)) !important',
+      },
     },
     controlHandlers: [
       {
@@ -26,11 +35,27 @@ function getSerpHandler(): SerpHandler {
       },
     ],
     entryHandlers: [
+      // Web
       {
         target: '#results.section > .fdb',
         url: '.result-header',
         title: '.snippet-title',
         actionTarget: '.result-header',
+        actionStyle: {
+          fontSize: 'var(--text-sm)',
+        },
+      },
+      // Images
+      {
+        target: '#img-holder > div > div[id^=img-]',
+        url: '.img-url',
+        title: '.img-title',
+        actionTarget: '.image-container',
+        actionStyle: {
+          position: 'relative',
+          top: '30px',
+          fontSize: 'var(--text-sm-2)',
+        },
       },
     ],
   });

--- a/src/scripts/search-engines/brave.ts
+++ b/src/scripts/search-engines/brave.ts
@@ -1,0 +1,42 @@
+import { SEARCH_ENGINES } from '../../common/search-engines';
+import { SearchEngine, SerpHandler } from '../types';
+import { handleSerp } from './helpers';
+
+function getSerpHandler(): SerpHandler {
+  return handleSerp({
+    globalStyle: {
+      '[data-ub-blocked="visible"]': {
+        backgroundColor: 'var(--ub-block-color, rgba(255, 192, 192, 0.5)) !important',
+      },
+      '.ub-button': {
+        color: 'var(--ub-link-color, var(--search-interactive-01))',
+      },
+      '.ub-button:hover': {
+        textDecoration: 'underline',
+      },
+    },
+    controlHandlers: [
+      {
+        target: '#filters-bar',
+        style: {
+          fontSize: '.66rem',
+          whiteSpace: 'nowrap',
+          padding: '4px',
+        },
+      },
+    ],
+    entryHandlers: [
+      {
+        target: '#results.section > .fdb',
+        url: '.result-header',
+        title: '.snippet-title',
+        actionTarget: '.result-header',
+      },
+    ],
+  });
+}
+
+export const brave: Readonly<SearchEngine> = {
+  ...SEARCH_ENGINES.brave,
+  getSerpHandler,
+};


### PR DESCRIPTION
Requested in <https://github.com/iorate/ublacklist/issues/203> and <https://github.com/iorate/ublacklist/issues/233>

Currently, the "In the News" and "Videos" sections of web search are not supported.

## Supported searches

- [x] Web search (*partially)
- [x] Image search
- [x] News search
- [x] Video search

## Screenshots

### Web search
[![Image from Gyazo](https://i.gyazo.com/fc222dcb4165b3b32cc38fa62356a14a.jpg)](https://gyazo.com/fc222dcb4165b3b32cc38fa62356a14a)

### Image search
[![Image from Gyazo](https://i.gyazo.com/710e272842cc8be17677b95f87ff70d8.jpg)](https://gyazo.com/710e272842cc8be17677b95f87ff70d8)

### News search
[![Image from Gyazo](https://i.gyazo.com/59409b1b7aaae93486a1aced70ed957f.jpg)](https://gyazo.com/59409b1b7aaae93486a1aced70ed957f)

### Video search
[![Image from Gyazo](https://i.gyazo.com/34b0cda4df170bd61c8976dc1f330053.jpg)](https://gyazo.com/34b0cda4df170bd61c8976dc1f330053)
