### PR TITLE
Add longer update intervals, implements #326

### DIFF
--- a/src/scripts/options/subscription-section.tsx
+++ b/src/scripts/options/subscription-section.tsx
@@ -50,6 +50,21 @@ const PERMISSION_PASSLIST = [
   '*://cdn.statically.io/*',
 ];
 
+const UPDATE_INTERVAL_OPTIONS = [
+  60, // an hour
+  120, // 2 hours
+  180, // 3 hours
+  360, // 6 hours
+  720, // 12 hours
+  1440, // a day
+  10080, // 7 days
+  20160, // 14 days
+  43200, // a month
+  86400, // 2 months
+  259200, // 6 months
+  525600, // a year
+];
+
 async function requestPermission(urls: readonly string[]): Promise<boolean> {
   const origins: string[] = [];
   const passlist = PERMISSION_PASSLIST.map(pass => new MatchPattern(pass));
@@ -491,7 +506,7 @@ export const SubscriptionSection: React.VFC = () => {
             }
             itemKey="updateInterval"
             label={translate('options_updateInterval')}
-            valueOptions={[60, 120, 180, 360, 720, 1440]}
+            valueOptions={UPDATE_INTERVAL_OPTIONS}
           />
         </SectionItem>
       </SectionBody>


### PR DESCRIPTION
Per #326, adds additional update interval options.

As discussed in the issue, updates may happen more frequently than specified if the user restarts their browser often. This could be addressed as an option in a separate PR. However this PR still has value as we could set a high update interval that may never trigger, instead relying on the update on restart function.