### PR TITLE
searx: add search.whatever.social

### DIFF
--- a/src/common/search-engines.ts
+++ b/src/common/search-engines.ts
@@ -458,6 +458,7 @@ export const SEARCH_ENGINES: Readonly<Record<SearchEngineId, Readonly<SearchEngi
           '*://search.serginho.dev/search*',
           '*://searx.netzspielplatz.de/search*',
           '*://searx.thefloatinglab.world/search*',
+          '*://search.whatever.social/searxng/search*',
         ],
         runAt: 'document_start',
       },


### PR DESCRIPTION
https://whatever.social:
> Whatever Social is a collection of FOSS alternative frontends and self-hosted services to try and close the gap between viewing mainstream social media and privacy

They recently added a searx instance, ~https://searx.whatever.social~ https://search.whatever.social