### PR TITLE
Add SpamdexingSites feed

### DIFF
--- a/website/src/pages/subscriptions.md
+++ b/website/src/pages/subscriptions.md
@@ -33,6 +33,8 @@ title: Subscriptions
   - "Blocklist to filter out spam and junk domains from search engines results"
 - [Super-SEO-Spam-Suppressor](https://github.com/NotaInutilis/Super-SEO-Spam-Suppressor) by [Nota Inutilis](https://github.com/NotaInutilis)
   - "Domains blocklist of sites abusing SEO tactics to spam web searches with advertisement, empty content (monetized with ads) and malware (looking like ads)."
+- [SpamdexingSites](https://github.com/elliotwutingfeng/SpamdexingSites) by [Wu Tingfeng](https://github.com/elliotwutingfeng)
+  - "URL feed for blocking spamdexing websites."
 
 ## Chinese {#chinese}
 


### PR DESCRIPTION
Here is my automatically generated feed of spamdexing websites formatted for ublacklist.

> [Spamdexing](https://en.wikipedia.org/wiki/Spamdexing) is the deliberate manipulation of search engine indexes. It involves a number of methods, such as link building and repeating unrelated phrases, to manipulate the relevance or prominence of resources indexed, in a manner inconsistent with the purpose of the indexing system.