### PR TITLE
Add a link to Subscriptions from Advanced Features

### DIFF
--- a/website/docs/advanced-features.md
+++ b/website/docs/advanced-features.md
@@ -174,4 +174,6 @@ To publish a ruleset as a subscription, place a ruleset file encoded in UTF-8 on
 
 It is a good idea to host your subscription on GitHub. Make sure that you publish the **raw** URL (e.g. https://raw.githubusercontent.com/iorate/ublacklist-example-subscription/master/uBlacklist.txt).
 
+A list of known public subscription lists can be found on the [Subscriptions](/subscriptions) page.
+
 ![raw url](/img/advanced-features/subscription-3.png)


### PR DESCRIPTION
I keep going to [Advanced Features’ Subscriptions](https://iorate.github.io/ublacklist/docs/advanced-features#subscription) section for the link and missing the link in the header of the page. Surely I’m not the only one… right? 😅