### PR TITLE
docs(website): Add Peter Lowe’s server list

### DIFF
--- a/website/src/pages/subscriptions.md
+++ b/website/src/pages/subscriptions.md
@@ -37,6 +37,10 @@ title: Subscriptions
   - "Domains blocklist of sites abusing SEO tactics to spam web searches with advertisement, empty content (monetized with ads) and malware (looking like ads)."
 - [SpamdexingSites](https://github.com/elliotwutingfeng/SpamdexingSites) by [Wu Tingfeng](https://github.com/elliotwutingfeng)
   - "URL feed for blocking spamdexing websites."
+- [Ad and tracking server domain list](https://pgl.yoyo.org/adservers/) by [Peter Lowe](https://pgl.yoyo.org/)
+  - "Ad and tracking server domain list maintained since 2001."
+  - "Doesn’t have a dedicated uBlacklist/match patterns format, but use of the [`prepend`](https://pgl.yoyo.org/as/formats.php#prepend) and [`append`](https://pgl.yoyo.org/as/formats.php#append) parameters produce a URL that works perfectly for uBlacklist:
+    - "`https://pgl.yoyo.org/as/serverlist.php?hostformat=plain&mimetype=plaintext&prepend=*://*.&append=/*&showintro=0`"
 
 ## Chinese {#chinese}
 


### PR DESCRIPTION
While this is not being published directly targeting uBlacklist or even with a default export for “match patterns”, it is easy enough to use with uBlacklist using the [`prepend`](https://pgl.yoyo.org/as/formats.php#prepend) and [`append`](https://pgl.yoyo.org/as/formats.php#append) options with the [`plain` `hostformat`](https://pgl.yoyo.org/as/formats.php#plain).

As such, a usable URL has been included as an example in the text, so downstream users can just copy/paste it from the list into their own subscriptions/configurations.