### PR TITLE
Fixed Discussions and Forums on Google Desktop

### DIFF
--- a/src/scripts/search-engines/google-desktop.ts
+++ b/src/scripts/search-engines/google-desktop.ts
@@ -203,8 +203,11 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
         target: ".LJ7wUe",
         url: "a",
         title: '[role="heading"][aria-level="3"]',
-        actionTarget: '[aria-label][role="link"]',
-        actionStyle: desktopActionStyle,
+        actionTarget: ".iDBaYb",
+        actionStyle: {
+          fontSize: "12px",
+          margin: "0 0 0 -12px",
+        },
       },
       // Featured Snippet
       {


### PR DESCRIPTION
# Summary

This fixes the issue #457, where uBlacklist fails to block entries in the "Discussions and Forums" section on Google Desktop.

## Technical Explanation

The main problem seems to be the fact that the previous rule was targeting an element that had a `role` attribute with the value `link`, but in the current version of Google, the element now has a `role="button"`.

Changing this seems to fix the issue, but the problem was that the div in which the action was inserted had a lot of styles conflicting with the ones from the extension.

Instead, I changed the target to a div with the class `.iDBaYb`, that seems to be more reliable.

## Result

![fixed-forums-discussions-google](https://github.com/iorate/ublacklist/assets/109992671/e02147b0-73c8-4bb0-a001-bb60482f04d8)
