### PR TITLE
Add support for images on Google "All" page

### DIFF
--- a/src/scripts/search-engines/google-desktop.ts
+++ b/src/scripts/search-engines/google-desktop.ts
@@ -367,8 +367,7 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
       },
       // Images (on the "All" page)
       {
-        target: ".JMWMJ",
-        level: ".eA0Zlc",
+        target: ".eA0Zlc",
         url: "a",
         title: ".toI8Rb",
         actionTarget: ".guK3rf",

--- a/src/scripts/search-engines/google-desktop.ts
+++ b/src/scripts/search-engines/google-desktop.ts
@@ -367,7 +367,7 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
       },
       // Images (on the "All" page)
       {
-        target: ".eA0Zlc",
+        target: ".eA0Zlc.mkpRId.RLdvSe",
         url: "a",
         title: ".toI8Rb",
         actionTarget: ".guK3rf",
@@ -395,7 +395,7 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
         target: '.autopagerize_page_info ~ div, [id^="arc-srp"] > div',
         // Regular, Video, and YouTube and TikTok channel
         innerTargets:
-          "[data-snf], [data-sokoban-feature], [data-content-feature], .IsZvec, .g, .iHxmLe, .d3zsgb, .rULfzc",
+          "[data-snf], [data-sokoban-feature], [data-content-feature], .IsZvec, .g, .iHxmLe, .d3zsgb, .rULfzc, .eA0Zlc.mkpRId.RLdvSe",
       },
     ],
   }),

--- a/src/scripts/search-engines/google-desktop.ts
+++ b/src/scripts/search-engines/google-desktop.ts
@@ -365,6 +365,19 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
         actionTarget: ".ZE0LJd, .S1FAPd",
         actionStyle: desktopActionStyle,
       },
+      // Images (on the "All" page)
+      {
+        target: ".JMWMJ",
+        level: ".eA0Zlc",
+        url: "a",
+        title: ".toI8Rb",
+        actionTarget: ".guK3rf",
+        actionStyle: {
+          ...desktopActionStyle,
+          position: "relative",
+          zIndex: "1",
+        },
+      },
     ],
     pagerHandlers: [
       // People Also Ask


### PR DESCRIPTION
# Summary

This PR adds a feature suggested by issue #462, where images in the "All" section of Google Desktop are now supported by the extension.

Here's a demo:

[demo-images.webm](https://github.com/iorate/ublacklist/assets/109992671/8f3adde4-7e45-4e29-9b45-6d178a364ae3)

## Additional Comments

*Now with the knowledge from the master, I'm closer to enlightenment...*

Jokes aside, thanks for you suggestion to use `pageHandlers`, I was about to go down some weird rabbit hole involving delays and `setTimeout`.

By the way, the use of recursion in the following snippet was really clever, my brain got really happy when I understood it LOL.

https://github.com/iorate/ublacklist/blob/4a9a5e0d11a07b26f0aecc87586628bdb3754381/src/scripts/search-engines/helpers.ts#L308-L317