### PR TITLE
Fix Extension Behavior On Unsupported udm Values

### DIFF
--- a/src/scripts/search-engines/google-desktop.ts
+++ b/src/scripts/search-engines/google-desktop.ts
@@ -665,7 +665,9 @@ export function getDesktopSerpHandler(
   tbm: string,
   udm: string,
 ): SerpHandler | null {
-  const serpHandler = desktopSerpHandlers[udm ? `udm=${udm}` : tbm];
+  const udmKey = `udm=${udm}`;
+  const serpHandler =
+    desktopSerpHandlers[udmKey in desktopSerpHandlers ? udmKey : tbm];
   if (!serpHandler) {
     return null;
   }


### PR DESCRIPTION
# Summary

This PR solves an issue reported on #465 where uBlacklist was not working on Google's new "Web" filter. (More details on the bug report.)

This was happening because, previously, if an `udm` value was present in a Google URL but its number was not supported by the extension (such as 14), uBlacklist would not return any `serpHandler` on Google Desktop.

Now, instead, if an `udm` value is present but not supported, the `tbm` is used instead. (Like the code was trying to do before.)

![Screenshot from 2024-05-24 22-07-56](https://github.com/iorate/ublacklist/assets/109992671/b04594a6-c76d-4fb1-8d75-111e0b492d2b)

![web-filter](https://github.com/iorate/ublacklist/assets/109992671/3a01e228-47e2-4a9e-92b9-079dbf14c527)
