### PR TITLE
Fix Positioning of Control Header on Google Desktop

### DIFF
--- a/src/scripts/search-engines/google-desktop.ts
+++ b/src/scripts/search-engines/google-desktop.ts
@@ -139,6 +139,9 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
           controlRoot.className = css({
             "#slim_appbar > &:not(:only-child)": {
               display: "none",
+              "#appbar": {
+                margin: "none !important",
+              },
             },
           });
           // Set appropriate margin when "Tools" bar is present:
@@ -151,6 +154,10 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
               // Present
               "&:is(.hdtb-ab-o)": {
                 margin: "42px 0 -12px",
+              },
+              // Remove margin when no entry has been blocked
+              "&:has(.ub-hidden)": {
+                margin: "0 !important",
               },
             }),
           );

--- a/src/scripts/search-engines/google-desktop.ts
+++ b/src/scripts/search-engines/google-desktop.ts
@@ -131,6 +131,9 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
           "#hdtbMenus :is(.BfdGL.ZkEmPc + div) &": {
             display: "block",
           },
+          ":not(#hdtbMenus) &": {
+            paddingLeft: "8px",
+          },
         },
       },
       {
@@ -139,9 +142,6 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
           controlRoot.className = css({
             "#slim_appbar > &:not(:only-child)": {
               display: "none",
-              "#appbar": {
-                margin: "none !important",
-              },
             },
           });
           // Set appropriate margin when "Tools" bar is present:
@@ -538,6 +538,9 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
           "#hdtbMenus :is(.BfdGL.ZkEmPc + div) &": {
             display: "block",
           },
+          ":not(#hdtbMenus) &": {
+            paddingLeft: "8px",
+          },
         },
       },
     ],
@@ -627,6 +630,9 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
           "#hdtbMenus :is(.BfdGL.ZkEmPc + div) &": {
             display: "block",
           },
+          ":not(#hdtbMenus) &": {
+            paddingLeft: "8px",
+          },
         },
       },
     ],
@@ -685,6 +691,9 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
           // Displays on the next line when part of the "Tools" bar
           "#hdtbMenus :is(.BfdGL.ZkEmPc + div) &": {
             display: "block",
+          },
+          ":not(#hdtbMenus) &": {
+            paddingLeft: "8px",
           },
         },
       },

--- a/src/scripts/search-engines/google-desktop.ts
+++ b/src/scripts/search-engines/google-desktop.ts
@@ -139,6 +139,22 @@ const regularControlHandlers: ControlHandler[] = [
           },
         }),
       );
+      // Set appropriate margin when there is an additional labels bar
+      if (controlRoot.matches(":scope:is(:is(div + #tU52Vb) :scope)")) {
+        controlRoot.closest("#appbar")?.classList.add(
+          css({
+            margin: "0 0 24px 0 !important",
+          }),
+        );
+        controlRoot.closest("#slim_appbar")?.classList.add(
+          css({
+            ".hdtb-ab-o &": {
+              padding: "48px 0 0 0",
+            },
+            padding: "24px 0 0 0",
+          }),
+        );
+      }
     },
   },
 ];

--- a/src/scripts/search-engines/google-desktop.ts
+++ b/src/scripts/search-engines/google-desktop.ts
@@ -1,6 +1,7 @@
 import { type CSSAttribute, css } from "../styles.ts";
 import type { SerpHandler } from "../types.ts";
 import {
+  type ControlHandler,
   type EntryHandler,
   handleSerp,
   hasDarkBackground,
@@ -100,6 +101,48 @@ const regularEntryHandler: Pick<
   },
 };
 
+const regularControlHandlers: ControlHandler[] = [
+  {
+    target: "#result-stats",
+    style: {
+      // Displays on the next line when part of the "Tools" bar
+      "#hdtbMenus :is(.BfdGL.ZkEmPc + div) &": {
+        display: "block",
+      },
+      ":not(#hdtbMenus) &": {
+        paddingLeft: "8px",
+      },
+    },
+  },
+  {
+    target: "#slim_appbar:empty",
+    style: (controlRoot) => {
+      controlRoot.className = css({
+        "#slim_appbar > &:not(:only-child)": {
+          display: "none",
+        },
+      });
+      // Set appropriate margin when "Tools" bar is present:
+      controlRoot.closest("#appbar")?.classList.add(
+        css({
+          // Not present
+          "&:not(.hdtb-ab-o)": {
+            margin: "16px 0",
+          },
+          // Present
+          "&:is(.hdtb-ab-o)": {
+            margin: "42px 0 -12px",
+          },
+          // Remove margin when no entry has been blocked
+          "&:has(.ub-hidden)": {
+            margin: "0 !important",
+          },
+        }),
+      );
+    },
+  },
+];
+
 const desktopSerpHandlers: Record<string, SerpHandler> = {
   // All
   "": handleSerp({
@@ -124,45 +167,7 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
       },
     },
     controlHandlers: [
-      {
-        target: "#result-stats",
-        style: {
-          // Displays on the next line when part of the "Tools" bar
-          "#hdtbMenus :is(.BfdGL.ZkEmPc + div) &": {
-            display: "block",
-          },
-          ":not(#hdtbMenus) &": {
-            paddingLeft: "8px",
-          },
-        },
-      },
-      {
-        target: "#slim_appbar:empty",
-        style: (controlRoot) => {
-          controlRoot.className = css({
-            "#slim_appbar > &:not(:only-child)": {
-              display: "none",
-            },
-          });
-          // Set appropriate margin when "Tools" bar is present:
-          controlRoot.closest("#appbar")?.classList.add(
-            css({
-              // Not present
-              "&:not(.hdtb-ab-o)": {
-                margin: "16px 0",
-              },
-              // Present
-              "&:is(.hdtb-ab-o)": {
-                margin: "42px 0 -12px",
-              },
-              // Remove margin when no entry has been blocked
-              "&:has(.ub-hidden)": {
-                margin: "0 !important",
-              },
-            }),
-          );
-        },
-      },
+      ...regularControlHandlers,
       {
         target: "#botabar",
         position: "afterend",
@@ -530,20 +535,7 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
   // Books
   bks: handleSerp({
     globalStyle: desktopGlobalStyle,
-    controlHandlers: [
-      {
-        target: "#result-stats",
-        style: {
-          // Displays on the next line when part of the "Tools" bar
-          "#hdtbMenus :is(.BfdGL.ZkEmPc + div) &": {
-            display: "block",
-          },
-          ":not(#hdtbMenus) &": {
-            paddingLeft: "8px",
-          },
-        },
-      },
-    ],
+    controlHandlers: [...regularControlHandlers],
     entryHandlers: [
       {
         target: ".Yr5TG",
@@ -622,20 +614,7 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
         whiteSpace: "nowrap",
       },
     },
-    controlHandlers: [
-      {
-        target: "#result-stats",
-        style: {
-          // Displays on the next line when part of the "Tools" bar
-          "#hdtbMenus :is(.BfdGL.ZkEmPc + div) &": {
-            display: "block",
-          },
-          ":not(#hdtbMenus) &": {
-            paddingLeft: "8px",
-          },
-        },
-      },
-    ],
+    controlHandlers: [...regularControlHandlers],
     entryHandlers: [
       // Regular
       {
@@ -684,20 +663,7 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
   // Videos
   vid: handleSerp({
     globalStyle: desktopGlobalStyle,
-    controlHandlers: [
-      {
-        target: "#result-stats",
-        style: {
-          // Displays on the next line when part of the "Tools" bar
-          "#hdtbMenus :is(.BfdGL.ZkEmPc + div) &": {
-            display: "block",
-          },
-          ":not(#hdtbMenus) &": {
-            paddingLeft: "8px",
-          },
-        },
-      },
-    ],
+    controlHandlers: [...regularControlHandlers],
     entryHandlers: [
       {
         target: ".g, .iHxmLe",

--- a/src/scripts/search-engines/google-desktop.ts
+++ b/src/scripts/search-engines/google-desktop.ts
@@ -126,6 +126,12 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
     controlHandlers: [
       {
         target: "#result-stats",
+        style: {
+          // Displays on the next line when part of the "Tools" bar
+          "#hdtbMenus :is(.BfdGL.ZkEmPc + div) &": {
+            display: "block",
+          },
+        },
       },
       {
         target: "#slim_appbar:empty",
@@ -520,6 +526,12 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
     controlHandlers: [
       {
         target: "#result-stats",
+        style: {
+          // Displays on the next line when part of the "Tools" bar
+          "#hdtbMenus :is(.BfdGL.ZkEmPc + div) &": {
+            display: "block",
+          },
+        },
       },
     ],
     entryHandlers: [
@@ -603,6 +615,12 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
     controlHandlers: [
       {
         target: "#result-stats",
+        style: {
+          // Displays on the next line when part of the "Tools" bar
+          "#hdtbMenus :is(.BfdGL.ZkEmPc + div) &": {
+            display: "block",
+          },
+        },
       },
     ],
     entryHandlers: [
@@ -656,6 +674,12 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
     controlHandlers: [
       {
         target: "#result-stats",
+        style: {
+          // Displays on the next line when part of the "Tools" bar
+          "#hdtbMenus :is(.BfdGL.ZkEmPc + div) &": {
+            display: "block",
+          },
+        },
       },
     ],
     entryHandlers: [

--- a/src/scripts/search-engines/google-desktop.ts
+++ b/src/scripts/search-engines/google-desktop.ts
@@ -129,10 +129,25 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
       },
       {
         target: "#slim_appbar:empty",
-        style: {
-          "#slim_appbar > &:not(:only-child)": {
-            display: "none",
-          },
+        style: (controlRoot) => {
+          controlRoot.className = css({
+            "#slim_appbar > &:not(:only-child)": {
+              display: "none",
+            },
+          });
+          // Set appropriate margin when "Tools" bar is present:
+          controlRoot.closest("#appbar")?.classList.add(
+            css({
+              // Not present
+              "&:not(.hdtb-ab-o)": {
+                margin: "16px 0",
+              },
+              // Present
+              "&:is(.hdtb-ab-o)": {
+                margin: "42px 0 -12px",
+              },
+            }),
+          );
         },
       },
       {

--- a/src/scripts/search-engines/google-desktop.ts
+++ b/src/scripts/search-engines/google-desktop.ts
@@ -140,7 +140,7 @@ const regularControlHandlers: ControlHandler[] = [
         }),
       );
       // Set appropriate margin when there is an additional labels bar
-      if (controlRoot.matches(":scope:is(:is(div + #tU52Vb) :scope)")) {
+      if (controlRoot.matches(":is(:is(div + #tU52Vb) :scope)")) {
         controlRoot.closest("#appbar")?.classList.add(
           css({
             margin: "0 0 24px 0 !important",

--- a/src/scripts/search-engines/google-desktop.ts
+++ b/src/scripts/search-engines/google-desktop.ts
@@ -109,7 +109,7 @@ const regularControlHandlers: ControlHandler[] = [
       "#hdtbMenus :is(.BfdGL.ZkEmPc + div) &": {
         display: "block",
       },
-      ":not(#hdtbMenus) &": {
+      "&:not(#hdtbMenus &)": {
         paddingLeft: "8px",
       },
     },


### PR DESCRIPTION
# Summary

This PR fixes an issue reported on #463, where the uBlacklist control header bar (the one that shows how many sites were blocked) would overlap with the Google "Tools" bar.

## Demo

[control-header-demo.webm](https://github.com/iorate/ublacklist/assets/109992671/44df5a4c-8674-42d5-b5d8-8a6fe54d8f7a)

[Screencast from 2024-05-26 22-24-50.webm](https://github.com/iorate/ublacklist/assets/109992671/f1cb1665-c7a1-4e5f-af8f-3843dcfc30a4)

## Small Note

There is a very small use of the `:has()` selector here:

https://github.com/iorate/ublacklist/blob/af17cb81ab005b7199e0f7bb94a7d1626539b3b1/src/scripts/search-engines/google-desktop.ts#L158-L161

This is a rule that removes a little bit of the margin that was added when there is no blocked entries.

I've tested it on Firefox ESR, and everything is fine.

This is pretty much a case of [graceful degradation](https://en.wikipedia.org/wiki/Fault_tolerance).