### PR TITLE
Small Fix: Font theme on Youtube/Instagram Cards

### DIFF
--- a/src/scripts/search-engines/google-desktop.ts
+++ b/src/scripts/search-engines/google-desktop.ts
@@ -396,6 +396,7 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
               ?.parentElement?.querySelector(".MhN3hd")
           ) {
             actionRoot.parentElement?.style.setProperty("z-index", "1");
+            actionRoot.setAttribute("data-ub-dark", "1");
           }
           // Copy container style in order to fit the action on Instagram posts that
           // take all the available space.


### PR DESCRIPTION
# Summary

Fix problem on Google's light theme, where the action button would be too dark inside of a Youtube/Instagram card.

# Demo

Before:

![before](https://github.com/iorate/ublacklist/assets/109992671/7293f1f2-2bcb-4a77-83b3-24fe6b4fc125)

After:

![after](https://github.com/iorate/ublacklist/assets/109992671/7e5ccd38-2e71-4e02-a6bc-f591119a95ef)

Custom themes are not impacted:

![custom-theme](https://github.com/iorate/ublacklist/assets/109992671/f9d68f56-4d08-4729-a2aa-ea03d9e68024)
