### PR TITLE
Add/Fix uBlacklist Controls on Google Images (Desktop)

### DIFF
--- a/src/scripts/search-engines/google-desktop.ts
+++ b/src/scripts/search-engines/google-desktop.ts
@@ -568,11 +568,16 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
     globalStyle: desktopGlobalStyle,
     controlHandlers: [
       {
-        target: "#appbar",
-        position: "afterbegin",
+        target: "#hdtbMenus",
+        style: {
+          lineHeight: "22px",
+        },
+      },
+      {
+        target: "#hdtb-sc > .PHj8of",
         style: {
           display: "block",
-          margin: "10px 0",
+          margin: "5px 0",
         },
       },
     ],
@@ -596,9 +601,22 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
         target: ".cEPPT",
         position: "afterend",
         style: {
+          "html[data-ub-dark='1'] &": {
+            color: "rgb(154, 160, 166)",
+          },
           color: "#70757a",
           display: "block",
           padding: "0 0 11px 165px",
+        },
+      },
+      {
+        target: ".ECgenc .itb-h",
+        style: {
+          "html[data-ub-dark='1'] &": {
+            color: "rgb(154, 160, 166)",
+          },
+          color: "#70757a",
+          padding: "6px 0 0 18px",
         },
       },
     ],


### PR DESCRIPTION
# Summary

This PR is part of the solution for issue #475, improving support for uBlacklist controls on Google Images.

Both `tbm=isch` and `udm=2` were addressed.

![2](https://github.com/iorate/ublacklist/assets/109992671/37c44888-f5c9-45ed-8927-35cc438114a9)
![1](https://github.com/iorate/ublacklist/assets/109992671/f4c5118d-ac32-4b97-9d00-f45bd66a7ba7)
