### PR TITLE
Fix Images Page on Mobile Version of Google

### DIFF
--- a/src/scripts/search-engines/google-mobile.ts
+++ b/src/scripts/search-engines/google-mobile.ts
@@ -383,6 +383,10 @@ const mobileSerpHandlers: Record<string, SerpHandler> = {
           "#appbar:has(.ibkV0b[style='']) &": {
             paddingBottom: "12px",
           },
+          // Fix spacing when there is a "Sponsored" section:
+          "body:has(#tvcap:not(:empty)) &": {
+            paddingTop: "0",
+          },
         },
       },
       // Control on top of additional images

--- a/src/scripts/search-engines/google-mobile.ts
+++ b/src/scripts/search-engines/google-mobile.ts
@@ -372,20 +372,13 @@ const mobileSerpHandlers: Record<string, SerpHandler> = {
     controlHandlers: [
       // Main control on Images page
       {
-        target: "#appbar #hdtb-sc",
+        target: "#appbar",
         style: {
           "&:not(.ub-hidden)": {
             display: "block",
-            padding: "16px 0 0 16px",
+            padding: "8px 0 8px 16px",
+            fontSize: "13px",
             ...iOSButtonStyle,
-          },
-          // Add additional padding when "Tools" bar is visible.
-          "#appbar:has(.ibkV0b[style='']) &": {
-            paddingBottom: "12px",
-          },
-          // Fix spacing when there is a "Sponsored" section:
-          "body:has(#tvcap:not(:empty)) &": {
-            paddingTop: "0",
           },
         },
       },

--- a/src/scripts/search-engines/google-mobile.ts
+++ b/src/scripts/search-engines/google-mobile.ts
@@ -367,6 +367,43 @@ const mobileSerpHandlers: Record<string, SerpHandler> = {
       },
     ],
   }),
+  "udm=2": handleSerp({
+    globalStyle: mobileGlobalStyle,
+    controlHandlers: [
+      {
+        target: "#appbar",
+        position: "afterend",
+        style: {
+          "&:not(.ub-hidden)": {
+            display: "block",
+          },
+        },
+      },
+    ],
+    entryHandlers: [
+      // Regular Image
+      {
+        target: "[data-bla]",
+        level: ".srKDX.cvP2Ce > div",
+        url: "a",
+        actionTarget: ".N54PNb > [data-snf]:last-child",
+        actionPosition: "afterend",
+        actionStyle: {
+          display: "block",
+          fontSize: "11px",
+          padding: "0 0 8px 0",
+          ...iOSButtonStyle,
+        },
+      },
+    ],
+    pagerHandlers: [
+      // Continuos Scrolling
+      {
+        target: '[id^="arc-srp"], [decode-data-ved]',
+        innerTargets: "[data-bla]",
+      },
+    ],
+  }),
   // News
   nws: handleSerp({
     globalStyle: mobileGlobalStyle,

--- a/src/scripts/search-engines/google-mobile.ts
+++ b/src/scripts/search-engines/google-mobile.ts
@@ -477,8 +477,13 @@ const mobileSerpHandlers: Record<string, SerpHandler> = {
   }),
 };
 
-export function getMobileSerpHandler(tbm: string): SerpHandler | null {
-  const serpHandler = mobileSerpHandlers[tbm];
+export function getMobileSerpHandler(
+  tbm: string,
+  udm: string,
+): SerpHandler | null {
+  const udmKey = `udm=${udm}`;
+  const serpHandler =
+    mobileSerpHandlers[udmKey in mobileSerpHandlers ? udmKey : tbm];
   if (!serpHandler) {
     return null;
   }

--- a/src/scripts/search-engines/google-mobile.ts
+++ b/src/scripts/search-engines/google-mobile.ts
@@ -370,13 +370,34 @@ const mobileSerpHandlers: Record<string, SerpHandler> = {
   "udm=2": handleSerp({
     globalStyle: mobileGlobalStyle,
     controlHandlers: [
+      // Main control on Images page
       {
-        target: "#appbar",
-        position: "afterend",
+        target: "#appbar #hdtb-sc",
         style: {
           "&:not(.ub-hidden)": {
             display: "block",
+            padding: "16px 0 0 16px",
+            ...iOSButtonStyle,
           },
+          // Add additional padding when "Tools" bar is visible.
+          "#appbar:has(.ibkV0b[style='']) &": {
+            paddingBottom: "12px",
+          },
+        },
+      },
+      // Control on top of additional images
+      {
+        target: ".izYTqe > .PK06q:empty",
+        style: (controlRoot) => {
+          controlRoot.className = css({
+            paddingLeft: "18px",
+            ...iOSButtonStyle,
+          });
+          controlRoot.parentElement?.classList.add(
+            css({
+              marginBottom: "16px",
+            }),
+          );
         },
       },
     ],
@@ -386,6 +407,7 @@ const mobileSerpHandlers: Record<string, SerpHandler> = {
         target: "[data-bla]",
         level: ".srKDX.cvP2Ce > div",
         url: "a",
+        title: ".Q6A6Dc",
         actionTarget: ".N54PNb > [data-snf]:last-child",
         actionPosition: "afterend",
         actionStyle: {
@@ -395,12 +417,31 @@ const mobileSerpHandlers: Record<string, SerpHandler> = {
           ...iOSButtonStyle,
         },
       },
+      // Additional Images (when you click on a regular image)
+      {
+        target: ".isv-r",
+        url: "a:not([role='button'])",
+        title: "h3",
+        actionTarget: (root) => root,
+        actionStyle: {
+          display: "block",
+          fontSize: "12px",
+          lineHeight: "18px",
+          margin: "-2px 0 8px",
+          ...iOSButtonStyle,
+        },
+      },
     ],
     pagerHandlers: [
       // Continuos Scrolling
       {
         target: '[id^="arc-srp"], [decode-data-ved]',
         innerTargets: "[data-bla]",
+      },
+      // Additional Images
+      {
+        target: "c-wiz",
+        innerTargets: ".isv-r, .PK06q",
       },
     ],
   }),

--- a/src/scripts/search-engines/google.ts
+++ b/src/scripts/search-engines/google.ts
@@ -11,7 +11,7 @@ export const google: Readonly<SearchEngine> = {
     const tbm = params.get("tbm") ?? "";
     const udm = params.get("udm") ?? "";
     return mobile({ tablet: true })
-      ? getMobileSerpHandler(tbm)
+      ? getMobileSerpHandler(tbm, udm)
       : getDesktopSerpHandler(tbm, udm);
   },
 };


### PR DESCRIPTION
# Summary

This PR fixes #476, improving support for blocking images on the mobile version of Google search.

## Demo

[google-mobile-udm2.webm](https://github.com/iorate/ublacklist/assets/109992671/4f66eaaa-12ba-44ce-8ade-4ca0cf52b42d)

## Additional Comments

Currently, it seems that the mobile version of Google search mostly uses `udm=2`, instead of `tbm=isch`.

I tested on multiple devices, VPNs, and regions, and I was not able to get a `tbm=isch` on mobile.

I'm not sure why that's the case, but things are now working with the new `serpHandler`.