### PR TITLE
Expand Support for Blocking News on Google Mobile

### DIFF
--- a/src/scripts/search-engines/google-mobile.ts
+++ b/src/scripts/search-engines/google-mobile.ts
@@ -100,6 +100,11 @@ const iOSButtonStyle: CSSAttribute = {
   },
 };
 
+const mobileActionClickable: CSSAttribute = {
+  position: "relative",
+  zIndex: "1",
+};
+
 const mobileSerpHandlers: Record<string, SerpHandler> = {
   // All
   "": handleSerp({
@@ -485,6 +490,24 @@ const mobileSerpHandlers: Record<string, SerpHandler> = {
         title: ".vvjwJb",
         actionTarget: "",
         actionStyle: mobileRegularActionStyle,
+      },
+      {
+        target: ".SoAPf",
+        level: ".lU8tTd > [data-hveid]",
+        url: "a",
+        title: '[role="heading"][aria-level="3"]',
+        actionTarget: ".lSfe4c",
+        actionPosition: "afterend",
+        actionStyle: {
+          display: "block",
+          fontSize: "12px",
+          lineHeight: "16px",
+          marginTop: "-12px",
+          textAlign: "right",
+          ...mobileRegularActionStyle,
+          ...mobileActionClickable,
+          ...iOSButtonStyle,
+        },
       },
     ],
   }),

--- a/src/scripts/search-engines/google-mobile.ts
+++ b/src/scripts/search-engines/google-mobile.ts
@@ -499,7 +499,6 @@ const mobileSerpHandlers: Record<string, SerpHandler> = {
         actionTarget: ".lSfe4c",
         actionPosition: "afterend",
         actionStyle: {
-          display: "block",
           fontSize: "12px",
           lineHeight: "16px",
           marginTop: "-12px",


### PR DESCRIPTION
# Summary

This PR expands support for blocking news articles on the mobile version of Google search.

It also partially solves issue #470, though there are still things to do.

# Demo

[mobile-news-demo.webm](https://github.com/iorate/ublacklist/assets/109992671/71550b42-6fe1-46af-95f9-da3768068a69)
