### PR TITLE
Add support for blocking News Cards on DuckDuckGo

### DIFF
--- a/src/scripts/search-engines/duckduckgo.ts
+++ b/src/scripts/search-engines/duckduckgo.ts
@@ -181,6 +181,7 @@ const serpHandler = handleSerp({
     },
     // News Cards on the main page
     {
+      scope: "all",
       target: ".module--carousel__item",
       url: "a",
       title: "a",

--- a/src/scripts/search-engines/duckduckgo.ts
+++ b/src/scripts/search-engines/duckduckgo.ts
@@ -179,6 +179,38 @@ const serpHandler = handleSerp({
       },
       actionButtonStyle: "result__a",
     },
+    // News Cards on the main page
+    {
+      target: ".module--carousel__item",
+      url: "a",
+      title: "a",
+      actionPosition: "afterend",
+      actionTarget: ".module--carousel__footer",
+      actionStyle: (actionRoot) => {
+        actionRoot.className = css({
+          padding: "0 0.75em",
+          position: "absolute",
+          bottom: "6px",
+          zIndex: "1",
+          fontSize: "12px",
+          ".is-mobile &": {
+            padding: "0 16px",
+          },
+        });
+        // Increase card size to include the "Block this site" button:
+        actionRoot.closest(".module--carousel__items")?.classList.add(
+          css({
+            height: "320px",
+            "& > .module--carousel__item": {
+              height: "300px",
+            },
+            "& .module--carousel__footer": {
+              bottom: "32px",
+            },
+          }),
+        );
+      },
+    },
   ],
   pagerHandlers: [
     {


### PR DESCRIPTION
# Summary

The title pretty much sums it up.

## Demo

[ddg-news-cards.webm](https://github.com/iorate/ublacklist/assets/109992671/eb4aff8d-693d-431e-a350-4d566008465b)
