### PR TITLE
Fix Ecosia support

### DIFF
--- a/src/common/search-engines.ts
+++ b/src/common/search-engines.ts
@@ -307,7 +307,7 @@ export const SEARCH_ENGINES: Readonly<
     contentScripts: [
       {
         matches: ["https://www.ecosia.org/search?*"],
-        runAt: "document_start",
+        runAt: "document_idle",
       },
     ],
     messageNames: {

--- a/src/scripts/search-engines/ecosia.ts
+++ b/src/scripts/search-engines/ecosia.ts
@@ -1,6 +1,6 @@
 import { SEARCH_ENGINES } from "../../common/search-engines.ts";
 import type { SearchEngine, SerpHandler } from "../types.ts";
-import { handleSerp } from "./helpers.ts";
+import { handleSerp, hasDarkBackground } from "./helpers.ts";
 
 function getSerpHandler(): SerpHandler {
   return handleSerp({
@@ -45,6 +45,10 @@ function getSerpHandler(): SerpHandler {
     pageProps: {
       $site: "ecosia",
       $category: "web",
+    },
+    getDialogTheme: () => {
+      const layout = document.querySelector<HTMLElement>(".layout");
+      return layout && hasDarkBackground(layout) ? "dark" : "light";
     },
   });
 }


### PR DESCRIPTION
fix #487 

The "All" search is now built on Nuxt, so we should wait for it to render.
I have no idea why the problem depends on "Preferred search provider".