### PR TITLE
Yandex.ru Domain Support

### DIFF
--- a/src/common/search-engines.ts
+++ b/src/common/search-engines.ts
@@ -570,6 +570,7 @@ export const SEARCH_ENGINES: Readonly<
         matches: [
           // Web
           "https://ya.ru/search*",
+          "https://yandex.ru/search*",
           "https://yandex.com/search*",
           "https://yandex.ua/search*",
           "https://yandex.by/search*",


### PR DESCRIPTION
![image](https://github.com/iorate/ublacklist/assets/31570640/ef9657f3-180c-441f-a684-c6c1cda0a445)

Currently the Yandex search automatically redirects all users from Russia to the domain yandex.ru, which is not in the uBlacklist.

This commit fixes this by adding yandex.ru to the list.