### PR TITLE
fix(safari,google): bring action after "translate this page" to front

### DIFF
--- a/src/scripts/search-engines/google-desktop.ts
+++ b/src/scripts/search-engines/google-desktop.ts
@@ -85,6 +85,9 @@ const regularEntryHandler: Pick<
     root,
   actionPosition: (target) => {
     if (target.matches(".eFM0qc")) {
+      if (process.env.BROWSER === "safari") {
+        target.style.zIndex = "1";
+      }
       return insertActionBeforeMenu(target);
     }
     if (target.matches(".HGLrXd, .TbwUpd")) {


### PR DESCRIPTION
fix #493 