### PR TITLE
Expand support of blocking news cards on Google's 'All' page  (Firefox for Android)

### DIFF
--- a/src/scripts/search-engines/google-mobile.ts
+++ b/src/scripts/search-engines/google-mobile.ts
@@ -110,7 +110,7 @@ const mobileSerpHandlers: Record<string, SerpHandler> = {
   "": handleSerp({
     globalStyle: {
       ...mobileGlobalStyle,
-      "[data-ub-blocked] .ZINbbc, [data-ub-highlight] .ZINbbc, [data-ub-blocked] .D9l01, [data-ub-highlight] .D9l01, .BmkBMc g-inner-card":
+      ":is([data-ub-blocked], [data-ub-highlight]) :is(.ZINbbc, .D9l01, .y6CIle), .BmkBMc g-inner-card":
         {
           backgroundColor: "transparent !important",
         },

--- a/src/scripts/search-engines/google-mobile.ts
+++ b/src/scripts/search-engines/google-mobile.ts
@@ -268,6 +268,25 @@ const mobileSerpHandlers: Record<string, SerpHandler> = {
           );
         },
       },
+      // Top / Related News
+      {
+        target: ".JJJtgd",
+        level: ".JJZKK",
+        url: "a",
+        title: ".pontCc > div",
+        actionTarget: ".JJJtgd",
+        actionPosition: "afterend",
+        actionStyle: {
+          fontSize: "12px",
+          lineHeight: "16px",
+          textAlign: "left",
+          marginBottom: "-6px",
+          paddingLeft: "8px !important",
+          ...mobileRegularActionStyle,
+          ...mobileActionClickable,
+          ...iOSButtonStyle,
+        },
+      },
     ],
     pagerHandlers: [
       // iOS


### PR DESCRIPTION
### Overview

When performing a Google search on Firefox for Android (Beta), top or related news cards frequently appear on the results page. Currently, it is not possible to block these news cards.
Therefore, this PR expands support for blocking news cards on the 'All' results page in order to block them.

### Before Changes
- As shown in the image below, it is not possible to block the news cards.

<img src="https://github.com/iorate/ublacklist/assets/11681008/8edfc499-960d-42b6-9e19-0857d7280930" alt="before" width="300" />

### After Changes

- As shown in the image below, it will be possible to block the news cards.

<img src="https://github.com/iorate/ublacklist/assets/11681008/e338ad1a-1c54-42c4-b4f4-0c9c9e52b758" alt="before" width="300" />

---

Thank you!