### PR TITLE
fix(ddg): fix button overlap on DDG card carousel in certain scenarios

### DIFF
--- a/src/scripts/search-engines/duckduckgo.ts
+++ b/src/scripts/search-engines/duckduckgo.ts
@@ -217,10 +217,13 @@ const serpHandler = handleSerp({
           },
         });
         // Increase card size to include the "Block this site" button:
-        actionRoot.closest(".module--carousel__items")?.classList.add(
+        actionRoot.closest(".module--carousel")?.classList.add(
           css({
-            height: "320px",
-            "& > .module--carousel__item": {
+            height: "unset !important",
+            "& .module--carousel__items": {
+              height: "320px",
+            },
+            "& .module--carousel__item": {
               height: "300px",
             },
             "& .module--carousel__footer": {


### PR DESCRIPTION
# Summary

It seems that when the end-user of DuckDuckGo changes the background color of the website, some additional styles are also added into the page, leading to a button overlap.

This PR fixes issue #502.

## Before

![Screenshot from 2024-07-21 20-55-13](https://github.com/user-attachments/assets/c27e5c79-30e8-4128-ab1d-16bd83dfbc2b)

## After

![Screenshot from 2024-07-21 22-06-40](https://github.com/user-attachments/assets/d61bf1a9-f52a-4c68-b1ea-961b8f41f6a9)
