### PR TITLE
Fix: Block Related Images on Google Images

### DIFF
--- a/src/scripts/search-engines/google-desktop.ts
+++ b/src/scripts/search-engines/google-desktop.ts
@@ -649,6 +649,23 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
           fontSize: "11px",
         },
       },
+      {
+        target: ".isv-r",
+        url: "a:not([role='button'])",
+        actionTarget: (root) => root,
+        actionStyle: {
+          display: "block",
+          fontSize: "12px",
+          lineHeight: "18px",
+          margin: "-2px 0 8px",
+        },
+      },
+    ],
+    pagerHandlers: [
+      {
+        target: "c-wiz",
+        innerTargets: ".isv-r",
+      },
     ],
     pageProps: {
       $site: "google",

--- a/src/scripts/search-engines/google-desktop.ts
+++ b/src/scripts/search-engines/google-desktop.ts
@@ -635,6 +635,7 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
         style: {
           display: "block",
           margin: "5px 0",
+          paddingLeft: "1.5rem",
         },
       },
     ],
@@ -647,6 +648,7 @@ const desktopSerpHandlers: Record<string, SerpHandler> = {
         actionStyle: {
           display: "block",
           fontSize: "11px",
+          paddingLeft: "4px",
         },
       },
       {


### PR DESCRIPTION
# Summary

This PR fixes issue #521 where related images on the Google Images page were not being blocked on Desktop.

Some minor alignment improvements for action/control buttons are also included.

![Screenshot from 2024-08-10 16-42-16](https://github.com/user-attachments/assets/bbaf2c2c-9143-4a34-8c69-6062b9b4a002)


## Technical Explanation

The `udm=2` handler on Desktop was missing a `pagerHandler` attached to a `serpEntry` rule.