### PR TITLE
Fix results with site links

### DIFF
--- a/src/scripts/search-engines/google-mobile.ts
+++ b/src/scripts/search-engines/google-mobile.ts
@@ -145,7 +145,7 @@ const mobileSerpHandlers: Record<string, SerpHandler> = {
             return null;
           }
           const webResultWithSiteLinks =
-            target.parentElement?.closest<HTMLElement>(".Ww4FFb.g, .mnr-c.g");
+            target.parentElement?.closest<HTMLElement>(".Ww4FFbs.vt6azsd");
           if (webResultWithSiteLinks) {
             return webResultWithSiteLinks;
           }

--- a/src/scripts/search-engines/google-mobile.ts
+++ b/src/scripts/search-engines/google-mobile.ts
@@ -145,7 +145,7 @@ const mobileSerpHandlers: Record<string, SerpHandler> = {
             return null;
           }
           const webResultWithSiteLinks =
-            target.parentElement?.closest<HTMLElement>(".Ww4FFbs.vt6azsd");
+            target.parentElement?.closest<HTMLElement>(".Ww4FFb.vt6azd");
           if (webResultWithSiteLinks) {
             return webResultWithSiteLinks;
           }


### PR DESCRIPTION
For search results which had links included at the bottom, the link cards were not being blocked. This fixes the issue.