### PR TITLE
build: manage pnpm and node with pnpm

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,0 +1,25 @@
+name: Setup pnpm
+
+description: A composite action to setup pnpm
+
+runs:
+  using: composite
+  steps:
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+
+    - name: Get pnpm store directory
+      run: echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Setup pnpm cache
+      uses: actions/cache@v4
+      with:
+        path: ${{ env.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
+
+    - name: Install dependencies
+      run: pnpm install
+      shell: bash

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -21,16 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install
+        uses: ./.github/actions/setup-pnpm
 
       - name: Check
         run: pnpm check-ci
@@ -57,7 +48,7 @@ jobs:
 
       - name: "[Website] Get changed files"
         id: website-changed-files
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@v45
         with:
           files: website/**
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,16 +26,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install
+        uses: ./.github/actions/setup-pnpm
 
       - name: Build
         run: |

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -21,16 +21,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install
+        uses: ./.github/actions/setup-pnpm
 
       - name: Build
         run: pnpm build

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 ignore-workspace-root-check=true
+manage-package-manager-versions=true
+use-node-version=22.9.0

--- a/README.md
+++ b/README.md
@@ -66,14 +66,15 @@ https://iorate.github.io/ublacklist/subscribe?url=https%3A%2F%2Fraw.githubuserco
 
 ### Build
 
-To build this extension, [Node.js](https://nodejs.org/en/)>=18 is required.
+To build this extension, [pnpm](https://pnpm.io/)>=9.7.0 or [corepack](https://github.com/nodejs/corepack) (currently distributed with Node.js) is required.
 
 ```shell
+# If you use corepack
+# corepack enable
+
 git clone https://github.com/iorate/ublacklist.git
 
 cd ublacklist
-
-corepack enable
 
 pnpm install
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -54,14 +54,15 @@ https://iorate.github.io/ublacklist/subscribe?name=Example&url=https%3A%2F%2Fraw
 
 ### 构建
 
-为了构建这个扩展，你需要下载并安装 [Node.js](https://nodejs.org/en/)>=18。
+为了构建这个扩展，你需要下载并安装 [pnpm](https://pnpm.io/)>=9.7.0 or [corepack](https://github.com/nodejs/corepack) (currently distributed with Node.js)。
 
 ```shell
+# If you use corepack
+# corepack enable
+
 git clone https://github.com/iorate/ublacklist.git
 
 cd ublacklist
-
-corepack enable
 
 pnpm install
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,10 @@
     "tsx": "^4.15.5",
     "typescript": "^5.4.5"
   },
-  "packageManager": "pnpm@9.3.0+sha512.ee7b93e0c2bd11409c6424f92b866f31d3ea1bef5fbe47d3c7500cdc3c9668833d2e55681ad66df5b640c61fa9dc25d546efa54d76d7f8bf54b13614ac293631",
+  "engines": {
+    "pnpm": ">=9.7.0"
+  },
+  "packageManager": "pnpm@9.10.0",
   "private": true,
   "scripts": {
     "build": "tsx scripts/build.ts",

--- a/release.config.ts
+++ b/release.config.ts
@@ -15,7 +15,8 @@ const amoPluginSpec: PluginSpec = [
     addonId: "ublacklist",
     addonDirPath: "dist/firefox",
     addonZipPath: "ublacklist-${nextRelease.gitTag}-firefox.zip",
-    approvalNotes: `To build this add-on, Node.js >= 18 is required.
+    approvalNotes: `To build this add-on, pnpm>=9.7.0 or corepack (currently distributed with Node.js) is required.
+If you use corepack, please run \`corepack enable\` in advance.
 
 $ cat << EOF > .env
 DROPBOX_API_KEY=${process.env.DROPBOX_API_KEY}
@@ -23,8 +24,6 @@ DROPBOX_API_SECRET=${process.env.DROPBOX_API_SECRET}
 GOOGLE_DRIVE_API_KEY=${process.env.GOOGLE_DRIVE_API_KEY}
 GOOGLE_DRIVE_API_SECRET=${process.env.GOOGLE_DRIVE_API_SECRET}
 EOF
-
-$ corepack enable
 
 $ pnpm install
 


### PR DESCRIPTION
This PR ensures consistent builds by locking specific versions of pnpm and Node.js. Developers using corepack won't be affected.