### PR TITLE
Fix element selectors in Ecosia

### DIFF
--- a/src/scripts/search-engines/ecosia.ts
+++ b/src/scripts/search-engines/ecosia.ts
@@ -31,8 +31,8 @@ function getSerpHandler(): SerpHandler {
     entryHandlers: [
       {
         target: ".result",
-        url: "a",
-        title: "a",
+        url: "a.result__link",
+        title: "h2.result-title__heading",
         actionTarget: (root) => root.querySelector(".result__body") || root,
         actionStyle: {
           display: "block",


### PR DESCRIPTION
The extension currently doesn't work for Ecosia, this PR makes it select the correct search result link and title (instead of Ecosia's search providers help article link every search result has)

Fixes #557