### PR TITLE
fix: subscription links UI in Safari

### DIFF
--- a/src/scripts/options/subscription-section.tsx
+++ b/src/scripts/options/subscription-section.tsx
@@ -540,9 +540,11 @@ export const SubscriptionSection: React.FC = () => {
           setSubscriptions={setSubscriptions}
           subscriptions={subscriptions}
         />
-        <Suspense fallback={null}>
-          <EnableSubscriptionURL type="ruleset" />
-        </Suspense>
+        {process.env.BROWSER !== "safari" && (
+          <Suspense fallback={null}>
+            <EnableSubscriptionURL type="ruleset" />
+          </Suspense>
+        )}
         <SectionItem>
           <SetIntervalItem
             disabled={


### PR DESCRIPTION
hide subscription link feature switch in Safari