### PR TITLE
fix: use subscription display name fallback in matching rules headers

### DIFF
--- a/src/scripts/options/subscription-section.tsx
+++ b/src/scripts/options/subscription-section.tsx
@@ -56,6 +56,7 @@ import type {
 } from "../types.ts";
 import {
   AltURL,
+  getSubscriptionDisplayName,
   isErrorResult,
   numberEntries,
   numberKeys,
@@ -64,14 +65,6 @@ import { FromNow } from "./from-now.tsx";
 import { useOptionsContext } from "./options-context.tsx";
 import { RulesetEditor } from "./ruleset-editor.tsx";
 import { SetIntervalItem } from "./set-interval-item.tsx";
-
-function getName(subscription: Readonly<Subscription>): string {
-  if (subscription.name) {
-    return subscription.name;
-  }
-  const name = subscription.ruleset?.metadata.name;
-  return typeof name === "string" ? name : subscription.url;
-}
 
 async function requestPermission(urls: readonly string[]): Promise<boolean> {
   const origins: string[] = [];
@@ -360,7 +353,7 @@ const ShowSubscriptionDialog: React.FC<
     <Dialog aria-labelledby={`${id}-title`} close={close} open={open}>
       <DialogHeader>
         <DialogTitle id={`${id}-title`}>
-          {subscription ? getName(subscription) : ""}
+          {subscription ? getSubscriptionDisplayName(subscription) : ""}
           {subscription?.type && subscription.type !== "ruleset" ? (
             <Badge className={badgeClassName}>{subscription.type}</Badge>
           ) : null}
@@ -469,7 +462,7 @@ const ManageSubscription: React.FC<{
       <TableCell>
         <LabelWrapper>
           <ControlLabel for={checkboxId}>
-            {getName(subscription)}
+            {getSubscriptionDisplayName(subscription)}
             {subscription.type && subscription.type !== "ruleset" ? (
               <Badge className={badgeClassName}>{subscription.type}</Badge>
             ) : null}

--- a/src/scripts/popup.tsx
+++ b/src/scripts/popup.tsx
@@ -18,7 +18,7 @@ import {
   EnableSerpInfoEmbeddedDialog,
   SerpInfoEmbeddedDialog,
 } from "./serpinfo/popup.tsx";
-import { fromPlainRuleset } from "./utilities.ts";
+import { fromPlainRuleset, getSubscriptionDisplayName } from "./utilities.ts";
 
 async function openOptionsPage(): Promise<void> {
   await sendMessage("open-options-page");
@@ -110,9 +110,12 @@ const Popup: React.FC = () => {
         fromPlainRuleset(options.ruleset || null, options.blacklist),
         Object.values(options.subscriptions)
           .filter((subscription) => subscription.enabled ?? true)
-          .map(({ ruleset, blacklist, name }) => ({
-            name,
-            ruleset: fromPlainRuleset(ruleset || null, blacklist),
+          .map((subscription) => ({
+            name: getSubscriptionDisplayName(subscription),
+            ruleset: fromPlainRuleset(
+              subscription.ruleset || null,
+              subscription.blacklist,
+            ),
           })),
       );
       setState({

--- a/src/scripts/serpinfo/filter.ts
+++ b/src/scripts/serpinfo/filter.ts
@@ -5,7 +5,7 @@ import { InteractiveRuleset } from "../interactive-ruleset.ts";
 import { translate } from "../locales.ts";
 import { postMessage } from "../messages.ts";
 import type { PlainRuleset, Subscriptions } from "../types.ts";
-import { fromPlainRuleset } from "../utilities.ts";
+import { fromPlainRuleset, getSubscriptionDisplayName } from "../utilities.ts";
 import {
   type ButtonProps,
   type PropertyCommand,
@@ -113,9 +113,12 @@ function createInteractiveRuleset(
     fromPlainRuleset(ruleset || null, blacklist),
     Object.values(subscriptions)
       .filter((subscription) => subscription.enabled ?? true)
-      .map(({ ruleset, blacklist, name }) => ({
-        name,
-        ruleset: fromPlainRuleset(ruleset || null, blacklist),
+      .map((subscription) => ({
+        name: getSubscriptionDisplayName(subscription),
+        ruleset: fromPlainRuleset(
+          subscription.ruleset || null,
+          subscription.blacklist,
+        ),
       })),
   );
 }

--- a/src/scripts/utilities.ts
+++ b/src/scripts/utilities.ts
@@ -12,6 +12,7 @@ import type {
   MatchingRulesText,
   PlainRuleset,
   Result,
+  Subscription,
   SuccessResult,
 } from "./types.ts";
 
@@ -153,6 +154,16 @@ export function numberEntries<Key extends number, Value>(
 // #region string
 export function lines(s: string): string[] {
   return s ? s.split("\n") : [];
+}
+
+export function getSubscriptionDisplayName(
+  subscription: Readonly<Subscription>,
+): string {
+  if (subscription.name) {
+    return subscription.name;
+  }
+  const name = subscription.ruleset?.metadata.name;
+  return typeof name === "string" ? name : subscription.url;
 }
 
 export function getMatchingRulesText(


### PR DESCRIPTION
The "show matching rules" feature rendered subscription headers using the raw `subscription.name`, which can be empty. The options page already applied a fallback chain (`name` → `ruleset.metadata.name` → `url`) via a local `getName` helper, but that logic was not used when building the `InteractiveRuleset`.

Extract the helper to `utilities.ts` as `getSubscriptionDisplayName` and use it in `popup.tsx` and `serpinfo/filter.ts` so matching-rules headers match what the options page shows.