### PR TITLE
fix: recognize private TLDs when suggesting block rules

### DIFF
--- a/src/scripts/block-dialog.tsx
+++ b/src/scripts/block-dialog.tsx
@@ -1,6 +1,5 @@
 import * as punycode from "punycode/";
 import { useId, useState } from "react";
-import * as tldts from "tldts";
 import icon from "../icons/icon.svg";
 import { ScopedBaseline } from "./components/baseline.tsx";
 import { Button, LinkButton } from "./components/button.tsx";
@@ -29,6 +28,7 @@ import { useClassName, usePrevious } from "./components/utilities.ts";
 import type { InteractiveRuleset } from "./interactive-ruleset.ts";
 import { translate } from "./locales.ts";
 import { PathDepth } from "./path-depth.ts";
+import { getRegistrableDomain } from "./registrable-domain.ts";
 import type { LinkProps } from "./ruleset/ruleset.ts";
 import type { DialogTheme, MatchingRulesText } from "./types.ts";
 import { getMatchingRulesText, makeAltURL, svgToDataURL } from "./utilities.ts";
@@ -79,7 +79,9 @@ const BlockDialogContent: React.FC<BlockDialogContentProps> = ({
       state.disabled = false;
       state.unblock = patch.unblock;
       state.host = punycode.toUnicode(
-        blockWholeSite ? (tldts.getDomain(url.host) ?? url.host) : url.host,
+        blockWholeSite
+          ? (getRegistrableDomain(url.host) ?? url.host)
+          : url.host,
       );
       state.detailsOpen = false;
       state.matchingRulesOpen = false;

--- a/src/scripts/interactive-ruleset.ts
+++ b/src/scripts/interactive-ruleset.ts
@@ -1,4 +1,4 @@
-import * as tldts from "tldts";
+import { getRegistrableDomain } from "./registrable-domain.ts";
 import {
   type LinkProps,
   Ruleset,
@@ -316,7 +316,7 @@ function suggestMatchPattern(
 ): string {
   let host = new URL(url).hostname;
   if (blockWholeSite) {
-    const domain = tldts.getDomain(host);
+    const domain = getRegistrableDomain(host);
     if (domain != null) {
       host = `*.${domain}`;
     }

--- a/src/scripts/interactive-ruleset.ts
+++ b/src/scripts/interactive-ruleset.ts
@@ -316,6 +316,9 @@ function suggestMatchPattern(
 ): string {
   let host = new URL(url).hostname;
   if (blockWholeSite) {
+    // `domain` is null when `host` itself is a public suffix (e.g.
+    // `vercel.app`). Fall back to the bare host to avoid suggesting
+    // `*.vercel.app`, which would match unrelated users' deployments.
     const domain = getRegistrableDomain(host);
     if (domain != null) {
       host = `*.${domain}`;

--- a/src/scripts/registrable-domain.ts
+++ b/src/scripts/registrable-domain.ts
@@ -1,0 +1,6 @@
+import * as tldts from "tldts";
+
+// Includes private TLDs (e.g. `pp.ua`, `github.io`) as effective TLDs.
+export function getRegistrableDomain(host: string): string | null {
+  return tldts.getDomain(host, { allowPrivateDomains: true });
+}


### PR DESCRIPTION
## Summary
Pass `allowPrivateDomains: true` to `tldts.getDomain()` so suffixes in the **PRIVATE** section of the Public Suffix List (`pp.ua`, `github.io`, `vercel.app`, etc.) are recognized as effective TLDs. Blocking `upsocial.pp.ua` now suggests `*://*.upsocial.pp.ua/*` instead of `*://*.pp.ua/*`.

Extracted into a new `registrable-domain.ts` module to keep the `tldts` / PSL data out of unrelated bundles.

Closes #778