### PR TITLE
chore: tighten subscription type to "ruleset" | "domains"

### DIFF
--- a/src/scripts/background/sync.ts
+++ b/src/scripts/background/sync.ts
@@ -256,7 +256,7 @@ const syncSections: readonly SyncSection[] = [
         .object({
           name: z.string(),
           url: z.string(),
-          type: z.string().optional(),
+          type: z.enum(["ruleset", "domains"]).optional(),
           enabled: z.boolean().optional(),
         })
         .array()

--- a/src/scripts/options/backup-restore-section.tsx
+++ b/src/scripts/options/backup-restore-section.tsx
@@ -106,7 +106,7 @@ export const BackupRestoreSection: React.FC<{ id: string }> = (props) => {
                         .object({
                           name: z.string(),
                           url: z.string(),
-                          type: z.string().optional(),
+                          type: z.enum(["ruleset", "domains"]).optional(),
                           enabled: z.boolean(),
                         })
                         .array()

--- a/src/scripts/types.ts
+++ b/src/scripts/types.ts
@@ -177,7 +177,7 @@ export type LocalStorageItemsBackupRestore = Pick<
   subscriptions: readonly {
     name: string;
     url: string;
-    type?: string;
+    type?: SubscriptionType;
     enabled: boolean;
   }[];
   serpInfoSettings: SerpInfoSettingsSerializable;
@@ -194,8 +194,7 @@ export type SubscriptionType = "ruleset" | "domains";
 export type Subscription = {
   name: string;
   url: string;
-  // string (not SubscriptionType) to preserve unknown types from future versions.
-  type?: string;
+  type?: SubscriptionType;
   ruleset?: PlainRuleset;
   blacklist: string;
   compiledRules?: string;


### PR DESCRIPTION
Follow-up to #773.

Tighten `Subscription.type` from `string` to the literal union
`"ruleset" | "domains"`, and make sync/restore reject unknown values instead
of silently accepting them.

The previous approach kept `type` as `string` so that a newer version adding
e.g. `type: "abp"` could still be synced or restored by older clients without
a parse error. On reflection, the opposite behavior is preferable: if an
older client encounters an unknown `type`, failing the sync/restore is
safer than creating a subscription it cannot actually handle. A sync error
does not stop the extension from working, and the user can resolve it by
updating the extension.