### PR TITLE
docs: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!--
+Thank you for the contribution. Please review CONTRIBUTING.md before submitting.
+https://github.com/iorate/ublacklist/blob/master/CONTRIBUTING.md
+
+Maintainers may skip or remove the checklist below.
+-->
+
+### Checklist
+
+- [ ] I have read [CONTRIBUTING.md](https://github.com/iorate/ublacklist/blob/master/CONTRIBUTING.md).
+- [ ] This is a trivial fix (typo fix, comment fix, minimal bug fix), or an issue is linked below.
+- [ ] This is not a translation change. (Translations are managed via [Crowdin](https://crowdin.com/project/ublacklist).)
+- [ ] `pnpm check` and `pnpm test` pass.
+
+### Linked issue
+
+<!-- For a major change, link the issue (e.g. "Fixes #123"). Trivial fixes may leave this empty. -->


### PR DESCRIPTION
- Adds `.github/PULL_REQUEST_TEMPLATE.md` to surface the contribution rules at PR creation time.
- Checklist covers reading CONTRIBUTING.md, the trivial-fix vs. major-change distinction, the translation carve-out (Crowdin), and `pnpm check` / `pnpm test`.
- HTML comment notes that maintainers may skip or remove the checklist.

Companion templates for `ublacklist/builtin`, `ublacklist/ublacklist.github.io`, and `ublacklist/store-assets` will be added separately.