### PR TITLE
docs: add related repositories section to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,3 +38,14 @@ After editing, run `pnpm check` to verify (this runs biome, prettier, and tsgo t
 
 1. Edit `src/_locales/en/messages.json` (English is the source of truth; other locales are managed via Crowdin — do not edit them directly).
 2. Run `pnpm generate:message-names` to regenerate message name constants.
+
+## Related Repositories
+
+uBlacklist is split across multiple repositories:
+
+- [iorate/ublacklist](https://github.com/iorate/ublacklist) — this repository, the extension itself.
+- [ublacklist/builtin](https://github.com/ublacklist/builtin) — built-in SERPINFO files (the extension downloads these periodically).
+- [ublacklist/ublacklist.github.io](https://github.com/ublacklist/ublacklist.github.io) — website and documentation.
+- [ublacklist/store-assets](https://github.com/ublacklist/store-assets) — store listing descriptions and screenshots.
+
+Changes to a specific subsystem belong in its repository.


### PR DESCRIPTION
- Adds a "Related Repositories" section to AGENTS.md that lists the four uBlacklist repositories (extension, builtin, website, store-assets) and their roles.
- Helps AI coding agents recognize that subsystem-specific changes belong in their respective repositories.