### PR TITLE
ci: link version headings to compare view in release notes

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -7,7 +7,11 @@
 # See https://keats.github.io/tera/docs/#introduction
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    {% if previous.version %}\
+        ## [{{ version | trim_start_matches(pat="v") }}](<REPO>/compare/{{ previous.version }}...{{ version }}) - {{ timestamp | date(format="%Y-%m-%d") }}
+    {% else %}\
+        ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    {% endif %}\
 {% else %}\
     ## [unreleased]
 {% endif %}\

--- a/cliff.toml
+++ b/cliff.toml
@@ -55,9 +55,10 @@ commit_parsers = [
     { message = "^(feat|fix)\\(i18n\\)", group = "<!-- 2 -->🌐 Translations" },
     { message = "^feat", group = "<!-- 0 -->🚀 Features" },
     { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = ".*", skip = true },
 ]
 # Exclude commits that are not matched by any commit parser.
-filter_commits = true
+filter_commits = false
 # Fail on a commit that is not matched by any commit parser.
 fail_on_unmatched_commit = false
 # An array of link parsers for extracting external references, and turning them into URLs, using regex.


### PR DESCRIPTION
Render each `## [x.y.z]` as an inline Markdown link to the GitHub compare view, following the official `keepachangelog.toml` example (with `...` to match GitHub's "Full Changelog" convention). For the unlikely cases where `version` or `previous.version` is missing, fall back to the linkless heading.

Also tidy up `commit_parsers`: add a catch-all `skip = true` entry so non-`feat`/`fix` commits (e.g. `ci:`) no longer trigger "Commit does not belong to any group" warnings, and revert `filter_commits` to its default now that the catch-all handles exclusion explicitly.