### PR TITLE
chore: pin virtualStoreDirMaxLength to 120 for AMO reproducible builds

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,3 +8,5 @@ blockExoticSubdeps: true
 minimumReleaseAge: 1440 # 1 day
 
 trustPolicy: no-downgrade
+
+virtualStoreDirMaxLength: 120 # pin for AMO reproducible builds


### PR DESCRIPTION
pnpm's virtualStoreDirMaxLength defaults to 120 on Linux/macOS and 60 on
Windows, which would cause the virtual store paths embedded in esbuild
bundle comments to diverge between CI (Ubuntu, 120) and a reviewer
reproducing the build on Windows (60). Pinning to 120 keeps every
environment aligned. This is a forward-looking hedge — v9.7.0 passed
review without it, presumably because the reviewer was on Linux/macOS.