### PR TITLE
ci: add actionlint and zizmor to CI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,10 +1,6 @@
 name: Check
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
   workflow_call:
   workflow_dispatch:
 
@@ -34,19 +30,19 @@ jobs:
           run_install: true
           cache: true
 
-      - name: Check by Biome
+      - name: pnpm biome ci
         run: pnpm biome ci --reporter=github
 
-      - name: Check by Prettier
+      - name: pnpm prettier
         run: pnpm prettier --check '**/*.{md,yaml,yml}'
 
-      - name: Check by TypeScript
+      - name: pnpm tsgo
         run: pnpm tsgo
 
-      - name: Test
+      - name: pnpm test
         run: pnpm test
 
-      - name: Build
+      - name: pnpm build
         run: |
           pnpm build
           pnpm build --browser firefox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  check:
+    permissions:
+      contents: read
+
+    uses: ./.github/workflows/check.yml
+
+  actionlint:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2.1.2
+
+  zizmor:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install actionlint
+        run: bash <(curl -s https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+
       - name: Run actionlint
-        uses: raven-actions/actionlint@205b530c5d9fa8f44ae9ed59f341a0db994aa6f8 # v2.1.2
+        run: ./actionlint -color
 
   zizmor:
     runs-on: ubuntu-latest

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -34,8 +34,10 @@ jobs:
         with:
           client-id: ${{ vars.PULL_REQUESTS_CLIENT_ID }}
           private-key: ${{ secrets.PULL_REQUESTS_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
-      - name: Crowdin
+      - name: Run crowdin
         uses: crowdin/github-action@8868a33591d21088edfc398968173a3b98d51706 # v2.16.2
         with:
           download_translations: true


### PR DESCRIPTION
Make check.yml a pure reusable workflow (removing direct push/PR
triggers) and introduce ci.yml as the entry point that calls check.yml
alongside new actionlint and zizmor jobs. This keeps check.yml callable
from the release workflow without running CI-only linters.

Also scope the GitHub App token in crowdin.yml to `contents:write` and
`pull-requests:write` (fixing a zizmor finding) and rename workflow step
names to match the commands they run.