### PR TITLE
fix: omit cookies in WebDAV requests

### DIFF
--- a/src/scripts/clouds/webdav.ts
+++ b/src/scripts/clouds/webdav.ts
@@ -1,8 +1,9 @@
 import dayjs from "dayjs";
 import dayjsUTC from "dayjs/plugin/utc";
 import {
-  createClient as createWebDAVClient,
+  createClient as _createClient,
   type FileStat,
+  getPatcher,
   type WebDAVClientError,
 } from "webdav";
 import type { WebDAV, WebDAVParams } from "../types.ts";
@@ -10,8 +11,13 @@ import { UnexpectedResponse } from "../utilities.ts";
 
 dayjs.extend(dayjsUTC);
 
+// Force `credentials: "omit"` so the host's cookies are never sent; we authenticate via the Authorization header.
+getPatcher().patch("fetch", (url: unknown, options: unknown) =>
+  fetch(url as string, { ...(options as RequestInit), credentials: "omit" }),
+);
+
 function createClient(params: WebDAVParams) {
-  return createWebDAVClient(params.url, {
+  return _createClient(params.url, {
     username: params.username,
     password: params.password,
   });


### PR DESCRIPTION
When the browser has an active session for the WebDAV host (e.g. logged into Nextcloud), its cookies were sent along with our requests. Nextcloud prioritizes that session over the Basic auth credentials we send, so the request fails with 401 (while logged in) or 403 (when the session belongs to a different account than the one in the URL).

The `webdav` library maps its `withCredentials` option to fetch's `credentials` but leaves the default `"same-origin"` when unset, so cookies are never omitted. Patch the library's `fetch` to force `credentials: "omit"`, since we authenticate solely via the Authorization header.

Closes #836.