### PR TITLE
chore: reword the WebDAV sync description for the single URL field

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -764,8 +764,8 @@
     "description": "Label for the radio button to sync with WebDAV."
   },
   "clouds_webdavSyncDescription": {
-    "message": "A file will be created at the URL specified.",
-    "description": "Label for the WebDAV URL input."
+    "message": "A file will be created within the folder at the URL.",
+    "description": "Description for WebDAV sync."
   },
   "clouds_webdavSyncTurnedOn": {
     "message": "Synced with WebDAV",


### PR DESCRIPTION
Follow-up to #838. After merging the WebDAV URL and destination folder into a single URL field, the sync description still read "A file will be created at the URL specified.", which framed the URL as the file's location rather than a folder. Reword it to "A file will be created within the folder at the URL.", matching the other backends' "A file will be created within …" phrasing and the new URL-field note. Also fix the message's translator description, which incorrectly said "Label for the WebDAV URL input."