### PR TITLE
chore(firefox): declare no data collection in the manifest

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -28,7 +28,10 @@ export function getManifest(context: ManifestContext) {
     ...(browser === "firefox"
       ? {
           browser_specific_settings: {
-            gecko: { id: "@ublacklist" },
+            gecko: {
+              id: "@ublacklist",
+              data_collection_permissions: { required: ["none"] },
+            },
             gecko_android: {},
           },
         }


### PR DESCRIPTION
Firefox Add-ons now warns that `browser_specific_settings.gecko.data_collection_permissions` is missing, and it will become required for new versions of existing extensions. uBlacklist stores data locally and only syncs to a cloud the user chooses (their own storage), so it doesn't collect or transmit data to the developer or third parties. Declare this with `required: ["none"]`, per Mozilla's "no data collection" guidance.