### PR TITLE
ci(edge): produce a keyless package for the Edge Add-ons store

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,8 +63,11 @@ jobs:
 
       - name: Build and archive (Edge)
         run: |
+          # Edge Add-ons rejects a manifest with the `key` field.
           pnpm build --browser edge --version "$VERSION"
           (cd dist/edge && zip -qr ../edge.zip .)
+          pnpm build --browser edge --version "$VERSION" --no-key
+          (cd dist/edge-no-key && zip -qr ../edge-no-key.zip .)
         env:
           VERSION: ${{ steps.next-version.outputs.version }}
           DROPBOX_API_KEY: ${{ secrets.DROPBOX_API_KEY }}
@@ -95,6 +98,7 @@ jobs:
           path: |
             dist/chrome.zip
             dist/edge.zip
+            dist/edge-no-key.zip
             dist/firefox.zip
             dist/release-notes.md
 
@@ -150,7 +154,7 @@ jobs:
         uses: iorate/setup-wepub@e37aebcc98937c8bfa4e22a438a4b89a75b4e349 # v1.0.0
 
       - name: Publish to Edge Add-ons
-        run: wepub edge dist/edge.zip --notes-file dist/notes-for-certification.txt
+        run: wepub edge dist/edge-no-key.zip --notes-file dist/notes-for-certification.txt
         env:
           WEPUB_EDGE_PRODUCT_ID: ${{ vars.EDGE_PRODUCT_ID }}
           WEPUB_EDGE_CLIENT_ID: ${{ secrets.EDGE_CLIENT_ID }}

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -106,23 +106,31 @@ async function main() {
       browser: { type: "string", short: "b" },
       version: { type: "string", short: "v" },
       debug: { type: "boolean", short: "d" },
+      "no-key": { type: "boolean" },
     },
   });
-  const { browser, version, debug } = z
+  const {
+    browser,
+    version,
+    debug,
+    "no-key": noKey,
+  } = z
     .object({
       browser: z
         .enum(["chrome", "edge", "firefox", "safari"])
         .default("chrome"),
       version: z.string().default("0.1.0"),
       debug: z.boolean().default(false),
+      "no-key": z.boolean().default(false),
     })
     .parse(args);
   const context = {
     browser,
     version,
     debug,
+    noKey,
     srcDir: "src",
-    destDir: `dist/${browser}${debug ? "-debug" : ""}`,
+    destDir: `dist/${browser}${debug ? "-debug" : ""}${noKey ? "-no-key" : ""}`,
   };
   await Promise.all([
     buildStaticAssets(context),

--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -4,10 +4,11 @@ export type ManifestContext = {
   browser: "chrome" | "edge" | "firefox" | "safari";
   version: string;
   debug: boolean;
+  noKey: boolean;
 };
 
 export function getManifest(context: ManifestContext) {
-  const { browser, version, debug } = context;
+  const { browser, version, debug, noKey } = context;
   return {
     action: {
       default_icon: {
@@ -58,15 +59,17 @@ export function getManifest(context: ManifestContext) {
       128: "icons/icon-128.png",
     },
 
-    ...(browser === "chrome"
-      ? {
-          key: "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAm+2y1Q2VH/S9rGxa/2kzRRspyxcA8R5QBa49JK/wca2kqyfpI/traqNnNY8SfRzOugtVP+8/WbyOY44wgr427VYws6thZ//cV2NDadEMqUF5dba9LR26QHXPFUWdbUyCtNHNVP4keG/OeGJ6thOrKUlxYorK9JAmdG1szucyOKt8+k8HNVfZFTi2UHGLn1ANLAsu6f4ykb6Z0QNNCysWuNHqtFEy4j0B4T+h5VZ+Il2l3yf8uGk/zAbJE7x0C7SIscBrWQ9jcliS/e25C6mEr5lrMhQ+VpVVsRVGg7PwY7xLywKHZM8z1nzLdpMs7egEqV25HiA/PEcaQRWwDKDqwQIDAQAB",
-        }
-      : browser === "edge"
+    ...(noKey
+      ? {}
+      : browser === "chrome"
         ? {
-            key: "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApHmUo0Lm4MLiXUB3qzfI0uwtiU3T77zYc2/oTKC8CwcUPaMAwro92p7Q2Iup9kmUWgXCy6hbiH3aU0sjwHojwSPQhlJW0IXe8OtgEK8raUBcvUhrBZhkZN4yDjwo62GPnBBiH0hFFOYfh0wyJML7g01K2MMvJbMGstnvcabN8NrUD/Ux+g05QchfNOM4J8e65Aq+nI3c77jQYj/Es5013WJLEFO/KQfn7dPSKY9CKvbvBXDtcjmZRr8cEM94IxwyBhwHwCE7hlk8wfQ+ChK3FnbQE5mUu3kP9XAKKvcrA9dlJPrJJdycVPfViacfSeK6/iCQGNIUaBAgJEBaKuFISwIDAQAB",
+            key: "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAm+2y1Q2VH/S9rGxa/2kzRRspyxcA8R5QBa49JK/wca2kqyfpI/traqNnNY8SfRzOugtVP+8/WbyOY44wgr427VYws6thZ//cV2NDadEMqUF5dba9LR26QHXPFUWdbUyCtNHNVP4keG/OeGJ6thOrKUlxYorK9JAmdG1szucyOKt8+k8HNVfZFTi2UHGLn1ANLAsu6f4ykb6Z0QNNCysWuNHqtFEy4j0B4T+h5VZ+Il2l3yf8uGk/zAbJE7x0C7SIscBrWQ9jcliS/e25C6mEr5lrMhQ+VpVVsRVGg7PwY7xLywKHZM8z1nzLdpMs7egEqV25HiA/PEcaQRWwDKDqwQIDAQAB",
           }
-        : {}),
+        : browser === "edge"
+          ? {
+              key: "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApHmUo0Lm4MLiXUB3qzfI0uwtiU3T77zYc2/oTKC8CwcUPaMAwro92p7Q2Iup9kmUWgXCy6hbiH3aU0sjwHojwSPQhlJW0IXe8OtgEK8raUBcvUhrBZhkZN4yDjwo62GPnBBiH0hFFOYfh0wyJML7g01K2MMvJbMGstnvcabN8NrUD/Ux+g05QchfNOM4J8e65Aq+nI3c77jQYj/Es5013WJLEFO/KQfn7dPSKY9CKvbvBXDtcjmZRr8cEM94IxwyBhwHwCE7hlk8wfQ+ChK3FnbQE5mUu3kP9XAKKvcrA9dlJPrJJdycVPfViacfSeK6/iCQGNIUaBAgJEBaKuFISwIDAQAB",
+            }
+          : {}),
 
     manifest_version: 3,
 


### PR DESCRIPTION
Edge Add-ons rejects a manifest containing the `key` field. The key is still wanted elsewhere — it pins the extension ID so cloud sync's OAuth redirect URIs stay stable, and the GitHub Releases artifact should keep it.

Add a `--no-key` build flag that omits the manifest `key` (output to a `-no-key` dist dir). The release workflow builds Edge twice: `edge.zip` (with key) for GitHub Releases, and `edge-no-key.zip` for the Edge Add-ons store.