### PR TITLE
feat(serpinfo): add the extraSelector property to result definitions

### DIFF
--- a/src/scripts/serpinfo/constants.ts
+++ b/src/scripts/serpinfo/constants.ts
@@ -4,7 +4,9 @@ export const attributes = {
   hideControl: "data-ub-hide-control",
   result: "data-ub-result",
   block: "data-ub-block",
+  preserveSpace: "data-ub-preserve-space",
   highlight: "data-ub-highlight",
+  extraSelector: "data-ub-extra-selector",
   iconButtonParent: "data-ub-icon-button-parent",
 };
 

--- a/src/scripts/serpinfo/content-script.ts
+++ b/src/scripts/serpinfo/content-script.ts
@@ -4,16 +4,20 @@ import isMobile from "is-mobile";
 import { createStore } from "zustand/vanilla";
 import { MatchPatternMap } from "../../common/match-pattern.ts";
 import iconSVG from "../../icons/icon.svg";
-import { defaultBlockColor } from "../constants.ts";
 import { translate } from "../locales.ts";
 import { addMessageListeners } from "../messages.ts";
 import { attributes as a, classes as c } from "./constants.ts";
-import { type CSSProperties, cssStringify } from "./css-stringify.ts";
+import { cssStringify } from "./css-stringify.ts";
 import { blockedResultCountStore, setupFilter } from "./filter.ts";
 import { setGlobalStyle, setStaticGlobalStyle } from "./global-styles.ts";
 import { createIsDarkModeStore } from "./is-dark-mode.ts";
 import type { SerpIndex } from "./settings.ts";
 import { storageStore } from "./storage-store.ts";
+import {
+  buildBlockStyle,
+  buildHideStyle,
+  buildHighlightStyle,
+} from "./style-builders.ts";
 
 const hideBlockedResultsStore = createStore(() => true);
 
@@ -76,18 +80,19 @@ function setupPopupListeners() {
   });
 }
 
-function setupStyles() {
-  const specificityBoost = ":not(#ub-never)";
+function setupStyles(serps: readonly SerpDescription[]) {
+  const extraSelectors = [
+    ...new Set(
+      serps.flatMap((serp) =>
+        serp.results.flatMap((result) =>
+          result?.extraSelector != null ? [result.extraSelector] : [],
+        ),
+      ),
+    ),
+  ];
+
   // Hide blocked results
-  setStaticGlobalStyle("hide-blocked-results", {
-    [`[${a.hideBlockedResults}] [${a.block}="1"]${specificityBoost}`]: {
-      display: "none !important",
-    },
-    [`[${a.hideBlockedResults}] [${a.block}="2"]${specificityBoost}, [${a.hideBlockedResults}] [${a.block}="2"]${specificityBoost} *`]:
-      {
-        visibility: "hidden !important" as "hidden",
-      },
-  });
+  setStaticGlobalStyle("hide-blocked-results", buildHideStyle(extraSelectors));
   toggleDocumentAttribute(
     a.hideBlockedResults,
     hideBlockedResultsStore.getState(),
@@ -120,36 +125,18 @@ function setupStyles() {
   // Block color
   storageStore.subscribe(
     (state) => state.blockColor,
-    (color) => {
-      setGlobalStyle("block-color", {
-        [`[${a.block}]${specificityBoost}`]: {
-          backgroundColor: `${color !== "default" ? color : defaultBlockColor} !important`,
-        },
-        [`[${a.block}]${specificityBoost} *`]: {
-          backgroundColor: "transparent !important",
-        },
-      });
-    },
+    (color) =>
+      setGlobalStyle("block-color", buildBlockStyle(extraSelectors, color)),
     { fireImmediately: true },
   );
   // Highlight colors
   storageStore.subscribe(
     (state) => state.highlightColors,
-    (colors) => {
-      let properties: CSSProperties = {};
-      for (const [index, color] of colors.entries()) {
-        properties = {
-          ...properties,
-          [`[${a.highlight}="${index + 1}"]${specificityBoost}`]: {
-            backgroundColor: `${color} !important`,
-          },
-          [`[${a.highlight}="${index + 1}"]${specificityBoost} *`]: {
-            backgroundColor: "transparent !important",
-          },
-        };
-      }
-      setGlobalStyle("highlight-colors", properties);
-    },
+    (colors) =>
+      setGlobalStyle(
+        "highlight-colors",
+        buildHighlightStyle(extraSelectors, colors),
+      ),
     { fireImmediately: true },
   );
 }
@@ -293,7 +280,7 @@ storageStore.attachPromise.then(() => {
   setupPopupListeners();
 
   const start = () => {
-    setupStyles();
+    setupStyles(serps);
     setupControl();
     setupFilter(serps);
   };

--- a/src/scripts/serpinfo/filter.ts
+++ b/src/scripts/serpinfo/filter.ts
@@ -261,6 +261,12 @@ class Filter {
       );
     }
     result.root.setAttribute(a.result, "1");
+    if (result.description.extraSelector != null) {
+      result.root.setAttribute(
+        a.extraSelector,
+        result.description.extraSelector,
+      );
+    }
     this.#judgeResult(result);
     this.#results.set(result.root, result);
   }
@@ -268,19 +274,22 @@ class Filter {
   #removeResult(result: Result) {
     result.removeButton?.();
     result.root.removeAttribute(a.result);
+    result.root.removeAttribute(a.extraSelector);
     if (result.root.hasAttribute(a.block)) {
-      result.root.removeAttribute(a.block);
       --this.#blockedResultCount;
     }
+    result.root.removeAttribute(a.block);
+    result.root.removeAttribute(a.preserveSpace);
     result.root.removeAttribute(a.highlight);
     this.#results.delete(result.root);
   }
 
   #judgeResult(result: Result) {
     if (result.root.hasAttribute(a.block)) {
-      result.root.removeAttribute(a.block);
       --this.#blockedResultCount;
     }
+    result.root.removeAttribute(a.block);
+    result.root.removeAttribute(a.preserveSpace);
     result.root.removeAttribute(a.highlight);
     if (result.url != null) {
       const queryResult = this.#ruleset.query({
@@ -288,10 +297,10 @@ class Filter {
         url: result.url,
       });
       if (queryResult?.type === "block") {
-        result.root.setAttribute(
-          a.block,
-          result.description.preserveSpace ? "2" : "1",
-        );
+        result.root.setAttribute(a.block, "1");
+        if (result.description.preserveSpace) {
+          result.root.setAttribute(a.preserveSpace, "1");
+        }
         ++this.#blockedResultCount;
       } else if (queryResult?.type === "highlight") {
         result.root.setAttribute(a.highlight, String(queryResult.colorNumber));

--- a/src/scripts/serpinfo/style-builders.test.ts
+++ b/src/scripts/serpinfo/style-builders.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { defaultBlockColor } from "../constants.ts";
+import {
+  buildBlockStyle,
+  buildHideStyle,
+  buildHighlightStyle,
+  expandExtraSelector,
+} from "./style-builders.ts";
+
+test("expandExtraSelector", async (t) => {
+  await t.test("replaces a single nesting selector", () => {
+    assert.deepEqual(expandExtraSelector("& + tr", "[data-ub-block]"), [
+      "[data-ub-block]+tr",
+    ]);
+  });
+
+  await t.test("returns one selector per top-level selector", () => {
+    assert.deepEqual(
+      expandExtraSelector("& + tr, & + tr + tr", "[data-ub-block]"),
+      ["[data-ub-block]+tr", "[data-ub-block]+tr+tr"],
+    );
+  });
+
+  await t.test("replaces every nesting selector in a selector", () => {
+    assert.deepEqual(expandExtraSelector("& + & + &", ".r"), [".r+.r+.r"]);
+  });
+
+  await t.test("replaces a nesting selector nested in :has()", () => {
+    assert.deepEqual(
+      expandExtraSelector(".header:has(+ &)", "[data-ub-block]"),
+      [".header:has(+[data-ub-block])"],
+    );
+  });
+
+  await t.test("returns an empty array for an invalid selector", () => {
+    assert.deepEqual(expandExtraSelector("&[", "[data-ub-block]"), []);
+  });
+});
+
+test("buildHideStyle", async (t) => {
+  await t.test("without extra selectors", () => {
+    assert.deepEqual(buildHideStyle([]), {
+      "[data-ub-hide-blocked-results] [data-ub-block]:not([data-ub-preserve-space]):not(#ub-never)":
+        { display: "none !important" },
+      "[data-ub-hide-blocked-results] [data-ub-block][data-ub-preserve-space]:not(#ub-never), [data-ub-hide-blocked-results] [data-ub-block][data-ub-preserve-space]:not(#ub-never) *":
+        { visibility: "hidden !important" },
+    });
+  });
+
+  await t.test("with an extra selector", () => {
+    const style = buildHideStyle(["& + tr"]);
+    const keys = Object.keys(style);
+    assert.equal(
+      keys[0],
+      '[data-ub-hide-blocked-results] [data-ub-block]:not([data-ub-preserve-space]):not(#ub-never), [data-ub-hide-blocked-results] [data-ub-extra-selector="& + tr"][data-ub-block]:not([data-ub-preserve-space]):not(#ub-never)+tr',
+    );
+    assert.equal(
+      keys[1],
+      '[data-ub-hide-blocked-results] [data-ub-block][data-ub-preserve-space]:not(#ub-never), [data-ub-hide-blocked-results] [data-ub-extra-selector="& + tr"][data-ub-block][data-ub-preserve-space]:not(#ub-never)+tr, [data-ub-hide-blocked-results] [data-ub-block][data-ub-preserve-space]:not(#ub-never) *, [data-ub-hide-blocked-results] [data-ub-extra-selector="& + tr"][data-ub-block][data-ub-preserve-space]:not(#ub-never)+tr *',
+    );
+  });
+});
+
+test("buildBlockStyle", async (t) => {
+  await t.test("resolves the default color", () => {
+    assert.deepEqual(buildBlockStyle([], "default"), {
+      "[data-ub-block]:not(#ub-never)": {
+        backgroundColor: `${defaultBlockColor} !important`,
+      },
+      "[data-ub-block]:not(#ub-never) *": {
+        backgroundColor: "transparent !important",
+      },
+    });
+  });
+
+  await t.test("uses an explicit color and includes extra selectors", () => {
+    const style = buildBlockStyle(["& + tr"], "#abcdef");
+    const keys = Object.keys(style);
+    assert.equal(
+      keys[0],
+      '[data-ub-block]:not(#ub-never), [data-ub-extra-selector="& + tr"][data-ub-block]:not(#ub-never)+tr',
+    );
+    assert.deepEqual(style[keys[0]], {
+      backgroundColor: "#abcdef !important",
+    });
+  });
+});
+
+test("buildHighlightStyle", async (t) => {
+  await t.test("one rule pair per color", () => {
+    assert.deepEqual(buildHighlightStyle([], ["#aaa", "#bbb"]), {
+      '[data-ub-highlight="1"]:not(#ub-never)': {
+        backgroundColor: "#aaa !important",
+      },
+      '[data-ub-highlight="1"]:not(#ub-never) *': {
+        backgroundColor: "transparent !important",
+      },
+      '[data-ub-highlight="2"]:not(#ub-never)': {
+        backgroundColor: "#bbb !important",
+      },
+      '[data-ub-highlight="2"]:not(#ub-never) *': {
+        backgroundColor: "transparent !important",
+      },
+    });
+  });
+
+  await t.test("includes extra selectors", () => {
+    const style = buildHighlightStyle(["& + tr"], ["#aaa"]);
+    assert.ok(
+      Object.keys(style).some((key) =>
+        key.includes(
+          '[data-ub-extra-selector="& + tr"][data-ub-highlight="1"]:not(#ub-never)+tr',
+        ),
+      ),
+    );
+  });
+});

--- a/src/scripts/serpinfo/style-builders.ts
+++ b/src/scripts/serpinfo/style-builders.ts
@@ -1,0 +1,119 @@
+import {
+  type CssNode,
+  clone,
+  generate,
+  type List,
+  type ListItem,
+  parse,
+  type Selector,
+  string,
+  walk,
+} from "css-tree";
+import { defaultBlockColor } from "../constants.ts";
+import { attributes as a } from "./constants.ts";
+import type { CSSProperties } from "./css-stringify.ts";
+
+const specificityBoost = ":not(#ub-never)";
+
+export function expandExtraSelector(
+  extraSelector: string,
+  rootSelector: string,
+): string[] {
+  try {
+    const extraNode = parse(extraSelector, { context: "selectorList" });
+    if (extraNode.type !== "SelectorList") {
+      throw new Error("extraSelector must be a selector list");
+    }
+    const rootNode = parse(rootSelector, { context: "selector" });
+    if (rootNode.type !== "Selector") {
+      throw new Error("rootSelector must be a selector");
+    }
+    const nestings: [ListItem<CssNode>, List<CssNode>][] = [];
+    walk(extraNode, (node, item, list) => {
+      if (node.type === "NestingSelector") {
+        nestings.push([item, list]);
+      }
+    });
+    for (const [item, list] of nestings) {
+      const replacement = clone(rootNode) as Selector;
+      list.replace(item, replacement.children);
+    }
+    const selectors: string[] = [];
+    extraNode.children.forEach((selector) => {
+      selectors.push(generate(selector));
+    });
+    return selectors;
+  } catch (error) {
+    console.error(error);
+    return [];
+  }
+}
+
+function buildSelector(
+  extraSelectors: readonly string[],
+  rootSelector: string,
+  prefix = "",
+  suffix = "",
+): string {
+  return [
+    `${prefix}${rootSelector}${specificityBoost}${suffix}`,
+    ...extraSelectors.flatMap((extraSelector) =>
+      expandExtraSelector(
+        extraSelector,
+        `[${a.extraSelector}=${string.encode(extraSelector)}]${rootSelector}${specificityBoost}`,
+      ).map((selector) => `${prefix}${selector}${suffix}`),
+    ),
+  ].join(", ");
+}
+
+export function buildHideStyle(
+  extraSelectors: readonly string[],
+): CSSProperties {
+  const displayRoot = `[${a.block}]:not([${a.preserveSpace}])`;
+  const visibilityRoot = `[${a.block}][${a.preserveSpace}]`;
+  const hidePrefix = `[${a.hideBlockedResults}] `;
+  return {
+    [buildSelector(extraSelectors, displayRoot, hidePrefix)]: {
+      display: "none !important",
+    },
+    [`${buildSelector(extraSelectors, visibilityRoot, hidePrefix)}, ${buildSelector(extraSelectors, visibilityRoot, hidePrefix, " *")}`]:
+      {
+        visibility: "hidden !important" as "hidden",
+      },
+  };
+}
+
+export function buildBlockStyle(
+  extraSelectors: readonly string[],
+  color: string,
+): CSSProperties {
+  const blockColorRoot = `[${a.block}]`;
+  return {
+    [buildSelector(extraSelectors, blockColorRoot)]: {
+      backgroundColor: `${color !== "default" ? color : defaultBlockColor} !important`,
+    },
+    [buildSelector(extraSelectors, blockColorRoot, "", " *")]: {
+      backgroundColor: "transparent !important",
+    },
+  };
+}
+
+export function buildHighlightStyle(
+  extraSelectors: readonly string[],
+  colors: readonly string[],
+): CSSProperties {
+  let properties: CSSProperties = {};
+  for (const [index, color] of colors.entries()) {
+    const highlightRoot = `[${a.highlight}="${index + 1}"]`;
+    properties = {
+      ...properties,
+      [buildSelector(extraSelectors, highlightRoot)]: {
+        backgroundColor: `${color} !important`,
+      },
+      [buildSelector(extraSelectors, highlightRoot, "", " *")]: {
+        backgroundColor: "transparent !important",
+      },
+    };
+  }
+  return properties;
+}


### PR DESCRIPTION
SERPINFO assumes one result maps to a single `root` element, so search
engines that split one result across multiple sibling elements with no
wrapper (e.g. lite.duckduckgo.com, where each result is several adjacent
`<tr>`s) could not be fully blocked or highlighted.

A result definition can now take an `extraSelector` — a selector list,
resolved relative to the matched `root` via the CSS nesting selector `&` —
naming extra elements that share the root's block/highlight state:

```yaml
results:
  - root: tr:has(.result-link)
    extraSelector: "& + tr, & + tr + tr"   # snippet and link-text rows
    url: .result-link
    props:
      title: .result-link
```

Addresses #846.
