### PR TITLE
fix: announce button labels by setting aria-label on svg elements

### DIFF
--- a/src/scripts/serpinfo/commands.ts
+++ b/src/scripts/serpinfo/commands.ts
@@ -4,6 +4,7 @@ import type {
   PropertyCommand,
   RootCommand,
 } from "@ublacklist/serpinfo";
+import { zip } from "es-toolkit";
 import punycode from "punycode/";
 import iconSVG from "../../icons/icon.svg";
 import { attributes as a, classes as c } from "./constants.ts";
@@ -284,8 +285,7 @@ const buttonCommandImpl: ButtonCommandImpl = {
             padding: 0,
             width: "max(var(--ub-icon-size), 40px)",
           },
-          span: {
-            display: "block",
+          svg: {
             height: "var(--ub-icon-size)",
             width: "var(--ub-icon-size)",
           },
@@ -293,20 +293,23 @@ const buttonCommandImpl: ButtonCommandImpl = {
         2,
       )}</style>
       <button type="button">
-        <span part="block">${iconSVG}</span>
-        <span part="unblock">${iconSVG}</span>
-        <span part="unhighlight">${iconSVG}</span>
+        ${iconSVG}
+        ${iconSVG}
+        ${iconSVG}
       </button>
     `;
-    const labels = {
-      block: context.buttonProps.blockLabel,
-      unblock: context.buttonProps.unblockLabel,
-      unhighlight: context.buttonProps.unhighlightLabel,
-    };
-    for (const [part, label] of Object.entries(labels)) {
-      // biome-ignore lint/style/noNonNullAssertion: the span always exists
-      shadowRoot.querySelector(`[part="${part}"]`)!.ariaLabel = label;
-    }
+    const partLabels = [
+      ["block", context.buttonProps.blockLabel],
+      ["unblock", context.buttonProps.unblockLabel],
+      ["unhighlight", context.buttonProps.unhighlightLabel],
+    ] as const;
+    zip([...shadowRoot.querySelectorAll("svg")], partLabels).forEach(
+      ([svg, [part, label]]) => {
+        svg.part = part;
+        svg.role = "img";
+        svg.ariaLabel = label;
+      },
+    );
     shadowRoot.querySelector("button")?.addEventListener("click", (event) => {
       event.stopPropagation();
       context.buttonProps.onClick(event);

--- a/src/scripts/serpinfo/content-script.ts
+++ b/src/scripts/serpinfo/content-script.ts
@@ -220,6 +220,7 @@ function setupControl() {
   });
   // biome-ignore lint/style/noNonNullAssertion: <svg> always exists
   const svg = button.querySelector("svg")!;
+  svg.role = "img";
   // biome-ignore lint/style/noNonNullAssertion: <span> always exists
   const span = button.querySelector("span")!;
 


### PR DESCRIPTION
Previously each icon was wrapped in a <span> whose aria-label was set in JS. aria-label has no effect on an element with a generic role, so the buttons effectively had no accessible name. Set role="img" and aria-label directly on the <svg> elements instead, and drop the now-redundant wrapper spans. The same role="img" fix is applied to the floating toggle button.