### PR TITLE
Add timeouts and concurrency guards to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
   check:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 30
+
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -52,6 +54,8 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 30
+
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -74,6 +78,8 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
 
+    timeout-minutes: 30
+
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -87,6 +93,8 @@ jobs:
 
   zizmor:
     runs-on: ubuntu-latest
+
+    timeout-minutes: 30
 
     permissions:
       security-events: write

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -11,6 +11,9 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}
+
 defaults:
   run:
     shell: bash
@@ -18,6 +21,8 @@ defaults:
 jobs:
   crowdin:
     runs-on: ubuntu-latest
+
+    timeout-minutes: 30
 
     steps:
       - name: Checkout

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}
+
 defaults:
   run:
     shell: bash
@@ -14,6 +17,8 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -80,6 +85,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    timeout-minutes: 30
+
     steps:
       - name: Download artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -103,6 +110,8 @@ jobs:
     needs: build
 
     runs-on: ubuntu-latest
+
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -137,6 +146,8 @@ jobs:
     needs: build
 
     runs-on: ubuntu-latest
+
+    timeout-minutes: 30
 
     steps:
       - name: Checkout
@@ -188,6 +199,8 @@ jobs:
     needs: [build, chrome, edge, firefox]
 
     runs-on: ubuntu-latest
+
+    timeout-minutes: 30
 
     permissions:
       contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,8 @@ on:
 
 permissions: {}
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+  group: ${{ github.workflow }}
 
 defaults:
   run:
@@ -16,6 +17,8 @@ defaults:
 jobs:
   release:
     runs-on: ubuntu-latest
+
+    timeout-minutes: 30
 
     permissions:
       contents: read

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -13,7 +13,6 @@ defaults:
 
 concurrency:
   group: ${{ github.workflow }}
-  cancel-in-progress: true
 
 jobs:
   renovate:


### PR DESCRIPTION
Add `timeout-minutes` to every job and a `concurrency` group to the
release, publish, crowdin, and renovate workflows so overlapping runs
serialize on the default `cancel-in-progress: false`.

CI deliberately gets no concurrency group: cancelling or coalescing
pushes risks skipping evaluation of a commit, which matters more than
the saved runner minutes.