### PR TITLE
Add concurrency control to the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ defaults:
   run:
     shell: bash
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -11,12 +11,12 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: ${{ github.workflow }}
-
 defaults:
   run:
     shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}
 
 jobs:
   crowdin:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,12 +7,12 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: ${{ github.workflow }}
-
 defaults:
   run:
     shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,12 +7,12 @@ on:
 
 permissions: {}
 
-concurrency:
-  group: ${{ github.workflow }}
-
 defaults:
   run:
     shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}
 
 jobs:
   release:


### PR DESCRIPTION
Also move the existing concurrency blocks below `defaults` in the
crowdin, publish, and release workflows to keep the key order consistent.
