### PR TITLE
Introduce CSS modules and CSS variable based theming

### DIFF
--- a/src/pages/options.html
+++ b/src/pages/options.html
@@ -6,6 +6,7 @@
     <meta name="color-scheme" content="dark light" />
     <meta name="viewport" content="width=device-width" />
     <title>Options</title>
+    <link rel="stylesheet" href="../scripts/options.css" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/pages/popup.html
+++ b/src/pages/popup.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8" />
     <meta name="color-scheme" content="dark light" />
     <meta name="viewport" content="width=device-width" />
+    <link rel="stylesheet" href="../scripts/popup.css" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/pages/serpinfo-options.html
+++ b/src/pages/serpinfo-options.html
@@ -6,6 +6,7 @@
     <meta name="color-scheme" content="dark light" />
     <meta name="viewport" content="width=device-width" />
     <title>SERPINFO Options</title>
+    <link rel="stylesheet" href="../scripts/serpinfo-options.css" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/scripts/components/badge.module.css
+++ b/src/scripts/components/badge.module.css
@@ -1,0 +1,9 @@
+.badge {
+  border: 1px solid var(--ub-color-border);
+  border-radius: 4px;
+  color: var(--ub-color-text-secondary);
+  font-size: 12px;
+  padding: 0 0.4em;
+  vertical-align: middle;
+  white-space: nowrap;
+}

--- a/src/scripts/components/badge.tsx
+++ b/src/scripts/components/badge.tsx
@@ -1,23 +1,11 @@
 import React from "react";
+import styles from "./badge.module.css";
 import { applyClassName } from "./helpers.tsx";
-import { useClassName } from "./utilities.ts";
 
 export type BadgeProps = React.JSX.IntrinsicElements["span"];
 
 export const Badge = React.forwardRef<HTMLSpanElement, BadgeProps>(
   function Badge(props, ref) {
-    const className = useClassName(
-      (theme) => ({
-        border: `1px solid ${theme.select.border}`,
-        borderRadius: "4px",
-        color: theme.text.secondary,
-        fontSize: "12px",
-        padding: "0 0.4em",
-        verticalAlign: "middle",
-        whiteSpace: "nowrap",
-      }),
-      [],
-    );
-    return <span {...applyClassName(props, className)} ref={ref} />;
+    return <span {...applyClassName(props, styles.badge ?? "")} ref={ref} />;
   },
 );

--- a/src/scripts/components/baseline.css
+++ b/src/scripts/components/baseline.css
@@ -1,0 +1,15 @@
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  font-size: 13px;
+  line-height: 1.5;
+  background: var(--ub-color-background);
+  color: var(--ub-color-text-primary);
+}

--- a/src/scripts/components/baseline.tsx
+++ b/src/scripts/components/baseline.tsx
@@ -1,53 +1,7 @@
-import { useLayoutEffect } from "react";
-import { useGlob } from "./styles.tsx";
 import { useClassName } from "./utilities.ts";
 
 const fontFamily =
   '-apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif';
-
-export type BaseLineProps = { children?: React.ReactNode; fontSize?: string };
-
-export const Baseline: React.FC<BaseLineProps> = ({
-  children,
-  fontSize = "13px",
-}) => {
-  const rootClassName = useClassName(
-    (theme) => ({
-      colorScheme: theme.name,
-    }),
-    [],
-  );
-  const bodyClassName = useClassName(
-    (theme) => ({
-      background: theme.background,
-      color: theme.text.primary,
-      margin: 0,
-      fontFamily,
-      fontSize,
-      lineHeight: 1.5,
-    }),
-    [fontSize],
-  );
-  useLayoutEffect(() => {
-    document.documentElement.classList.add(rootClassName);
-    document.body.classList.add(bodyClassName);
-    return () => {
-      document.documentElement.classList.remove(rootClassName);
-      document.body.classList.remove(bodyClassName);
-    };
-  }, [rootClassName, bodyClassName]);
-
-  const glob = useGlob();
-  useLayoutEffect(() => {
-    glob({
-      "*, *::before, *::after": {
-        boxSizing: "border-box",
-      },
-    });
-  }, [glob]);
-
-  return <>{children}</>;
-};
 
 export type ScopedBaselineProps = {
   children?: React.ReactNode;

--- a/src/scripts/components/theme.css
+++ b/src/scripts/components/theme.css
@@ -1,0 +1,61 @@
+.ub-root {
+  color-scheme: light;
+
+  --ub-color-background: rgb(248, 249, 250);
+  --ub-color-surface: white;
+  --ub-color-text-primary: rgb(32, 33, 36);
+  --ub-color-text-secondary: rgb(95, 99, 104);
+  --ub-color-text-disabled: rgb(128, 134, 139);
+  --ub-color-accent: rgb(26, 115, 232);
+  --ub-color-on-accent: white;
+  --ub-color-link: rgb(51, 103, 214);
+  --ub-color-border: rgb(218, 220, 224);
+  --ub-color-separator: rgba(0, 0, 0, 0.06);
+  --ub-color-focus-ring: rgba(26, 115, 232, 0.4);
+  --ub-color-focus-circle: rgba(26, 115, 232, 0.2);
+  --ub-color-shadow-strong: rgba(60, 64, 67, 0.3);
+  --ub-color-shadow-soft: rgba(60, 64, 67, 0.15);
+
+  --ub-button-primary-background-hovered: rgba(26, 115, 232, 0.9);
+  --ub-button-primary-background-active: rgba(26, 115, 232, 0.8);
+  --ub-button-primary-background-disabled: rgb(241, 243, 244);
+  --ub-button-secondary-background-hovered: rgba(66, 133, 244, 0.04);
+  --ub-button-secondary-background-active: rgba(66, 133, 244, 0.08);
+  --ub-menu-item-background-hovered: rgba(189, 193, 198, 0.15);
+  --ub-menu-item-background-focused: rgba(189, 193, 198, 0.3);
+  --ub-switch-bar: rgb(189, 193, 198);
+  --ub-switch-bar-checked: rgba(26, 115, 232, 0.5);
+  --ub-switch-knob: white;
+  --ub-switch-knob-border: rgb(218, 220, 224);
+}
+
+.ub-root[data-theme="dark"] {
+  color-scheme: dark;
+
+  --ub-color-background: rgb(32, 33, 36);
+  --ub-color-surface: rgb(41, 42, 45);
+  --ub-color-text-primary: rgb(232, 234, 237);
+  --ub-color-text-secondary: rgb(154, 160, 166);
+  --ub-color-text-disabled: rgb(128, 134, 139);
+  --ub-color-accent: rgb(138, 180, 248);
+  --ub-color-on-accent: rgb(32, 33, 36);
+  --ub-color-link: rgb(138, 180, 248);
+  --ub-color-border: rgb(95, 99, 104);
+  --ub-color-separator: rgba(255, 255, 255, 0.1);
+  --ub-color-focus-ring: rgba(138, 180, 248, 0.5);
+  --ub-color-focus-circle: rgba(138, 180, 248, 0.4);
+  --ub-color-shadow-strong: rgba(0, 0, 0, 0.3);
+  --ub-color-shadow-soft: rgba(0, 0, 0, 0.15);
+
+  --ub-button-primary-background-hovered: rgba(138, 180, 248, 0.9);
+  --ub-button-primary-background-active: rgba(138, 180, 248, 0.8);
+  --ub-button-primary-background-disabled: rgb(60, 64, 67);
+  --ub-button-secondary-background-hovered: rgba(138, 180, 248, 0.08);
+  --ub-button-secondary-background-active: rgba(138, 180, 248, 0.16);
+  --ub-menu-item-background-hovered: rgba(95, 99, 104, 0.3);
+  --ub-menu-item-background-focused: rgba(95, 99, 104, 0.6);
+  --ub-switch-bar: rgb(154, 160, 166);
+  --ub-switch-bar-checked: rgba(138, 180, 248, 0.5);
+  --ub-switch-knob: rgb(218, 220, 224);
+  --ub-switch-knob-border: transparent;
+}

--- a/src/scripts/components/theme.tsx
+++ b/src/scripts/components/theme.tsx
@@ -1,4 +1,10 @@
-import React, { useContext, useEffect, useRef, useState } from "react";
+import React, {
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 
 export type Theme = {
   name: string;
@@ -251,6 +257,99 @@ export const lightTheme: Readonly<Theme> = {
   },
 };
 
+const varThemeColors: Readonly<Omit<Theme, "name">> = {
+  background: "var(--ub-color-background)",
+  button: {
+    primary: {
+      background: "var(--ub-color-accent)",
+      backgroundActive: "var(--ub-button-primary-background-active)",
+      backgroundDisabled: "var(--ub-button-primary-background-disabled)",
+      backgroundHovered: "var(--ub-button-primary-background-hovered)",
+      text: "var(--ub-color-on-accent)",
+      textDisabled: "var(--ub-color-text-disabled)",
+    },
+    secondary: {
+      background: "transparent",
+      backgroundActive: "var(--ub-button-secondary-background-active)",
+      backgroundDisabled: "transparent",
+      backgroundHovered: "var(--ub-button-secondary-background-hovered)",
+      border: "var(--ub-color-border)",
+      text: "var(--ub-color-accent)",
+      textDisabled: "var(--ub-color-text-disabled)",
+    },
+  },
+  checkBox: {
+    border: "var(--ub-color-text-secondary)",
+    box: "var(--ub-color-accent)",
+    checkMark: "var(--ub-color-on-accent)",
+  },
+  colorPicker: {
+    border: "var(--ub-color-border)",
+    popoverBackground: "var(--ub-color-surface)",
+  },
+  dialog: {
+    background: "var(--ub-color-surface)",
+  },
+  editor: {
+    border: "var(--ub-color-border)",
+  },
+  focus: {
+    shadow: "var(--ub-color-focus-ring)",
+    circle: "var(--ub-color-focus-circle)",
+  },
+  iconButton: "var(--ub-color-text-secondary)",
+  input: {
+    border: "var(--ub-color-border)",
+  },
+  link: {
+    text: "var(--ub-color-link)",
+  },
+  menu: {
+    itemBackgroundFocused: "var(--ub-menu-item-background-focused)",
+    itemBackgroundHovered: "var(--ub-menu-item-background-hovered)",
+    itemListBackground: "var(--ub-color-surface)",
+  },
+  radioButton: {
+    unchecked: "var(--ub-color-text-secondary)",
+    checked: "var(--ub-color-accent)",
+  },
+  section: {
+    background: "var(--ub-color-surface)",
+    shadow1: "var(--ub-color-shadow-strong)",
+    shadow2: "var(--ub-color-shadow-soft)",
+  },
+  select: {
+    arrow: "var(--ub-color-text-secondary)",
+    border: "var(--ub-color-border)",
+    optionBackground: "var(--ub-color-surface)",
+  },
+  separator: "var(--ub-color-separator)",
+  switch: {
+    bar: "var(--ub-switch-bar)",
+    barChecked: "var(--ub-switch-bar-checked)",
+    knob: "var(--ub-switch-knob)",
+    knobBorder: "var(--ub-switch-knob-border)",
+    knobChecked: "var(--ub-color-accent)",
+  },
+  text: {
+    primary: "var(--ub-color-text-primary)",
+    secondary: "var(--ub-color-text-secondary)",
+  },
+  textArea: {
+    border: "var(--ub-color-border)",
+  },
+};
+
+export const varLightTheme: Readonly<Theme> = {
+  ...varThemeColors,
+  name: "light",
+};
+
+export const varDarkTheme: Readonly<Theme> = {
+  ...varThemeColors,
+  name: "dark",
+};
+
 export type ThemeProviderProps = { children?: React.ReactNode; theme: Theme };
 
 const ThemeContext = React.createContext<ThemeProviderProps>({
@@ -281,8 +380,12 @@ export const AutoThemeProvider: React.FC<{ children?: React.ReactNode }> = ({
       setDark(e.matches);
     });
   }, []);
+  useLayoutEffect(() => {
+    document.documentElement.classList.add("ub-root");
+    document.documentElement.dataset.theme = dark ? "dark" : "light";
+  }, [dark]);
   return (
-    <ThemeProvider theme={dark ? darkTheme : lightTheme}>
+    <ThemeProvider theme={dark ? varDarkTheme : varLightTheme}>
       {children}
     </ThemeProvider>
   );

--- a/src/scripts/options/index.tsx
+++ b/src/scripts/options/index.tsx
@@ -1,5 +1,6 @@
+import "../components/theme.css";
+import "../components/baseline.css";
 import { createRoot } from "react-dom/client";
-import { Baseline } from "../components/baseline.tsx";
 import { Container } from "../components/container.tsx";
 import { AutoThemeProvider } from "../components/theme.tsx";
 import { translate } from "../shared/locales.ts";
@@ -13,20 +14,18 @@ import { SyncSection } from "./sync-section.tsx";
 
 const Options: React.FC = () => (
   <AutoThemeProvider>
-    <Baseline>
-      <OptionsContextProvider>
-        <Container>
-          {/* biome-ignore-start lint/correctness/useUniqueElementIds: IDs are intentionally hardcoded for URL fragment navigation */}
-          <GeneralSection id="general" />
-          <AppearanceSection id="appearance" />
-          <SyncSection id="sync" />
-          <SubscriptionSection id="subscription" />
-          <BackupRestoreSection id="backup-restore" />
-          <AboutSection id="about" />
-          {/* biome-ignore-end lint/correctness/useUniqueElementIds: IDs are intentionally hardcoded for URL fragment navigation */}
-        </Container>
-      </OptionsContextProvider>
-    </Baseline>
+    <OptionsContextProvider>
+      <Container>
+        {/* biome-ignore-start lint/correctness/useUniqueElementIds: IDs are intentionally hardcoded for URL fragment navigation */}
+        <GeneralSection id="general" />
+        <AppearanceSection id="appearance" />
+        <SyncSection id="sync" />
+        <SubscriptionSection id="subscription" />
+        <BackupRestoreSection id="backup-restore" />
+        <AboutSection id="about" />
+        {/* biome-ignore-end lint/correctness/useUniqueElementIds: IDs are intentionally hardcoded for URL fragment navigation */}
+      </Container>
+    </OptionsContextProvider>
   </AutoThemeProvider>
 );
 

--- a/src/scripts/popup/index.tsx
+++ b/src/scripts/popup/index.tsx
@@ -1,3 +1,5 @@
+import "../components/theme.css";
+import "../components/baseline.css";
 import isMobile from "is-mobile";
 import { useEffect, useState } from "react";
 import { createRoot } from "react-dom/client";
@@ -5,7 +7,6 @@ import {
   BlockEmbeddedDialog,
   type BlockEmbeddedDialogProps,
 } from "../block-dialog.ts";
-import { Baseline } from "../components/baseline.tsx";
 import { AutoThemeProvider } from "../components/theme.tsx";
 import { useClassName } from "../components/utilities.ts";
 import { browser } from "../shared/browser.ts";
@@ -129,17 +130,15 @@ const Popup: React.FC = () => {
   }, []);
   return (
     <AutoThemeProvider>
-      <Baseline>
-        {state.type === "loading" ? (
-          <Loading />
-        ) : state.type === "serpInfo" ? (
-          <SerpInfoEmbeddedDialog {...state.props} />
-        ) : state.type === "enableSerpInfo" ? (
-          <EnableSerpInfoEmbeddedDialog />
-        ) : (
-          <BlockEmbeddedDialog {...state.props} />
-        )}
-      </Baseline>
+      {state.type === "loading" ? (
+        <Loading />
+      ) : state.type === "serpInfo" ? (
+        <SerpInfoEmbeddedDialog {...state.props} />
+      ) : state.type === "enableSerpInfo" ? (
+        <EnableSerpInfoEmbeddedDialog />
+      ) : (
+        <BlockEmbeddedDialog {...state.props} />
+      )}
     </AutoThemeProvider>
   );
 };

--- a/src/scripts/serpinfo-options/index.tsx
+++ b/src/scripts/serpinfo-options/index.tsx
@@ -4,9 +4,10 @@ import homeSVG from "@mdi/svg/svg/home.svg";
 import { parse, type SerpInfo } from "@ublacklist/serpinfo";
 import dayjs from "dayjs";
 import dayjsLocalizedFormat from "dayjs/plugin/localizedFormat";
+import "../components/theme.css";
+import "../components/baseline.css";
 import { Suspense, use, useEffect, useId, useRef, useState } from "react";
 import { createRoot } from "react-dom/client";
-import { Baseline } from "../components/baseline.tsx";
 import { Button, LinkButton } from "../components/button.tsx";
 import { FOCUS_END_CLASS, FOCUS_START_CLASS } from "../components/constants.ts";
 import { Container } from "../components/container.tsx";
@@ -592,11 +593,9 @@ function OptionsImpl() {
 function Options() {
   return (
     <AutoThemeProvider>
-      <Baseline>
-        <Suspense fallback={null}>
-          <OptionsImpl />
-        </Suspense>
-      </Baseline>
+      <Suspense fallback={null}>
+        <OptionsImpl />
+      </Suspense>
     </AutoThemeProvider>
   );
 }

--- a/src/scripts/shared/globals.ts
+++ b/src/scripts/shared/globals.ts
@@ -14,6 +14,15 @@ declare namespace NodeJS {
 // Commented out because webdav package pulls in @types/node, causing duplicate declaration.
 // declare var process: { env: NodeJS.ProcessEnv };
 
+declare module "*.module.css" {
+  const classes: Record<string, string>;
+  export default classes;
+}
+
+declare module "*/theme.css" {}
+
+declare module "*/baseline.css" {}
+
 declare module "*.svg" {
   const content: string;
   export default content;


### PR DESCRIPTION
Token mapping from the old `Theme` object.

Semantic tokens:

| Token | Light | Dark | Old `Theme` key(s) |
| --- | --- | --- | --- |
| `--ub-color-background` | rgb(248, 249, 250) | rgb(32, 33, 36) | background |
| `--ub-color-surface` | white | rgb(41, 42, 45) | section.background, dialog.background, menu.itemListBackground, colorPicker.popoverBackground, select.optionBackground |
| `--ub-color-text-primary` | rgb(32, 33, 36) | rgb(232, 234, 237) | text.primary |
| `--ub-color-text-secondary` | rgb(95, 99, 104) | rgb(154, 160, 166) | text.secondary, iconButton, checkBox.border, radioButton.unchecked, select.arrow |
| `--ub-color-text-disabled` | rgb(128, 134, 139) | rgb(128, 134, 139) | button.primary.textDisabled, button.secondary.textDisabled |
| `--ub-color-accent` | rgb(26, 115, 232) | rgb(138, 180, 248) | button.primary.background, button.secondary.text, checkBox.box, radioButton.checked, switch.knobChecked |
| `--ub-color-on-accent` | white | rgb(32, 33, 36) | button.primary.text, checkBox.checkMark |
| `--ub-color-link` | rgb(51, 103, 214) | rgb(138, 180, 248) | link.text |
| `--ub-color-border` | rgb(218, 220, 224) | rgb(95, 99, 104) | input.border, textArea.border, editor.border, select.border, colorPicker.border, button.secondary.border |
| `--ub-color-separator` | rgba(0, 0, 0, 0.06) | rgba(255, 255, 255, 0.1) | separator |
| `--ub-color-focus-ring` | rgba(26, 115, 232, 0.4) | rgba(138, 180, 248, 0.5) | focus.shadow |
| `--ub-color-focus-circle` | rgba(26, 115, 232, 0.2) | rgba(138, 180, 248, 0.4) | focus.circle |
| `--ub-color-shadow-strong` | rgba(60, 64, 67, 0.3) | rgba(0, 0, 0, 0.3) | section.shadow1 |
| `--ub-color-shadow-soft` | rgba(60, 64, 67, 0.15) | rgba(0, 0, 0, 0.15) | section.shadow2 |

Component tokens:

| Token | Light | Dark | Old `Theme` key |
| --- | --- | --- | --- |
| `--ub-button-primary-background-hovered` | rgba(26, 115, 232, 0.9) | rgba(138, 180, 248, 0.9) | button.primary.backgroundHovered |
| `--ub-button-primary-background-active` | rgba(26, 115, 232, 0.8) | rgba(138, 180, 248, 0.8) | button.primary.backgroundActive |
| `--ub-button-primary-background-disabled` | rgb(241, 243, 244) | rgb(60, 64, 67) | button.primary.backgroundDisabled |
| `--ub-button-secondary-background-hovered` | rgba(66, 133, 244, 0.04) | rgba(138, 180, 248, 0.08) | button.secondary.backgroundHovered |
| `--ub-button-secondary-background-active` | rgba(66, 133, 244, 0.08) | rgba(138, 180, 248, 0.16) | button.secondary.backgroundActive |
| `--ub-menu-item-background-hovered` | rgba(189, 193, 198, 0.15) | rgba(95, 99, 104, 0.3) | menu.itemBackgroundHovered |
| `--ub-menu-item-background-focused` | rgba(189, 193, 198, 0.3) | rgba(95, 99, 104, 0.6) | menu.itemBackgroundFocused |
| `--ub-switch-bar` | rgb(189, 193, 198) | rgb(154, 160, 166) | switch.bar |
| `--ub-switch-bar-checked` | rgba(26, 115, 232, 0.5) | rgba(138, 180, 248, 0.5) | switch.barChecked |
| `--ub-switch-knob` | white | rgb(218, 220, 224) | switch.knob |
| `--ub-switch-knob-border` | rgb(218, 220, 224) | transparent | switch.knobBorder (dark was undefined) |

`button.secondary.background` and `button.secondary.backgroundDisabled` are `transparent` in both themes and are not tokenized; the var bridge passes the literal value.
