### PR TITLE
Update the SVG icon only when it changes

### DIFF
--- a/src/scripts/components/svg-icon.tsx
+++ b/src/scripts/components/svg-icon.tsx
@@ -1,5 +1,6 @@
 import clsx from "clsx";
 import type React from "react";
+import { useLayoutEffect, useRef } from "react";
 import styles from "./svg-icon.module.css";
 
 export type SvgIconProps = React.JSX.IntrinsicElements["span"] & {
@@ -14,16 +15,18 @@ export function SvgIcon({
   svg,
   ...props
 }: SvgIconProps) {
+  const ref = useRef<HTMLSpanElement>(null);
+  useLayoutEffect(() => {
+    if (ref.current) {
+      ref.current.innerHTML = svg;
+    }
+  }, [svg]);
   return (
     <span
       aria-hidden={true}
       {...props}
       className={clsx(styles.icon, className)}
-      ref={(element) => {
-        if (element) {
-          element.innerHTML = svg;
-        }
-      }}
+      ref={ref}
       style={color != null ? { color, ...style } : style}
     />
   );


### PR DESCRIPTION
On macOS Safari, clicking a number field's increment/decrement button once with a mouse stepped the value twice. This affected the sync and update interval steppers on the options page. Touch input, Chrome, and Firefox were unaffected.

The cause was a three-way interaction:

- `SvgIcon` rebuilt its `<svg>` on every render (it set `innerHTML` in a ref callback that ran each render), so stepping — which re-renders the field — recreated the icon under the pointer.
- Since Safari 26.2, Safari dispatches `mouseenter` when the hit-test target under a stationary pointer changes, without any pointer movement.
- Base UI's number field resumes press-and-hold on a `mouseenter` while the button is held down, which performs one extra step.

So a single click stepped once on pointer-down and again from the `mouseenter` that Safari fired when the icon was recreated under the cursor.

`SvgIcon` now writes `innerHTML` only when `svg` changes, using a stable ref and `useLayoutEffect`, so nothing is recreated under the pointer during a step. As a side effect it also stops re-parsing the SVG on every render.

Ref: https://webkit.org/blog/17640/webkit-features-for-safari-26-2/

🤖 Generated with [Claude Code](https://claude.com/claude-code)
