### PR TITLE
Improve OAuth token refresh in Google Drive and Dropbox sync

### DIFF
--- a/.changeset/refresh-token-rotation.md
+++ b/.changeset/refresh-token-rotation.md
@@ -2,4 +2,4 @@
 "ublacklist": patch
 ---
 
-Google Drive and Dropbox sync now supports refresh token rotation, preventing sync from being unexpectedly disconnected if the provider starts issuing a new refresh token on every token refresh.
+Made Google Drive and Dropbox sync more robust: it now supports refresh token rotation, tolerates token responses without an expiration time, and renews access tokens shortly before they expire. This prevents sync from being unexpectedly disconnected if the provider changes its token endpoint behavior.

--- a/.changeset/refresh-token-rotation.md
+++ b/.changeset/refresh-token-rotation.md
@@ -1,0 +1,5 @@
+---
+"ublacklist": patch
+---
+
+Google Drive and Dropbox sync now supports refresh token rotation, preventing sync from being unexpectedly disconnected if the provider starts issuing a new refresh token on every token refresh.

--- a/.changeset/refresh-token-rotation.md
+++ b/.changeset/refresh-token-rotation.md
@@ -1,5 +1,0 @@
----
-"ublacklist": patch
----
-
-Made Google Drive and Dropbox sync more robust: it now supports refresh token rotation, tolerates token responses without an expiration time, and renews access tokens shortly before they expire. This prevents sync from being unexpectedly disconnected if the provider changes its token endpoint behavior.

--- a/src/scripts/shared/types.ts
+++ b/src/scripts/shared/types.ts
@@ -71,7 +71,7 @@ export type Cloud = {
 
 export type CloudToken = {
   accessToken: string;
-  expiresAt?: string;
+  expiresAt: string | null;
   refreshToken: string;
   pkce?: boolean;
 };

--- a/src/scripts/shared/types.ts
+++ b/src/scripts/shared/types.ts
@@ -45,7 +45,7 @@ export type Cloud = {
   refreshAccessToken(
     refreshToken: string,
     pkce?: boolean,
-  ): Promise<{ accessToken: string; expiresIn: number }>;
+  ): Promise<{ accessToken: string; expiresIn: number; refreshToken?: string }>;
   createFile(
     accessToken: string,
     filename: string,

--- a/src/scripts/shared/types.ts
+++ b/src/scripts/shared/types.ts
@@ -45,7 +45,11 @@ export type Cloud = {
   refreshAccessToken(
     refreshToken: string,
     pkce?: boolean,
-  ): Promise<{ accessToken: string; expiresIn: number; refreshToken?: string }>;
+  ): Promise<{
+    accessToken: string;
+    expiresIn: number | null;
+    refreshToken: string | null;
+  }>;
   createFile(
     accessToken: string,
     filename: string,
@@ -67,7 +71,7 @@ export type Cloud = {
 
 export type CloudToken = {
   accessToken: string;
-  expiresAt: string;
+  expiresAt?: string;
   refreshToken: string;
   pkce?: boolean;
 };

--- a/src/scripts/sync-backends/cloud-utils.ts
+++ b/src/scripts/sync-backends/cloud-utils.ts
@@ -190,9 +190,11 @@ export type RefreshAccessTokenParams = {
 export function refreshAccessToken(
   url: string,
   params: Readonly<RefreshAccessTokenParams>,
-): (
-  refreshToken: string,
-) => Promise<{ accessToken: string; expiresIn: number }> {
+): (refreshToken: string) => Promise<{
+  accessToken: string;
+  expiresIn: number;
+  refreshToken?: string;
+}> {
   return async (refreshToken) => {
     const response = await fetch(url, {
       method: "POST",
@@ -205,7 +207,11 @@ export function refreshAccessToken(
     if (response.ok) {
       const responseBody: unknown = await response.json();
       const parseResult = z
-        .object({ access_token: z.string(), expires_in: z.number() })
+        .object({
+          access_token: z.string(),
+          expires_in: z.number(),
+          refresh_token: z.string().optional(),
+        })
         .safeParse(responseBody);
       if (!parseResult.success) {
         throw new UnexpectedResponse(responseBody);
@@ -213,6 +219,9 @@ export function refreshAccessToken(
       return {
         accessToken: parseResult.data.access_token,
         expiresIn: parseResult.data.expires_in,
+        ...(parseResult.data.refresh_token != null
+          ? { refreshToken: parseResult.data.refresh_token }
+          : {}),
       };
     }
     throw new HTTPError(response.status, response.statusText);

--- a/src/scripts/sync-backends/cloud-utils.ts
+++ b/src/scripts/sync-backends/cloud-utils.ts
@@ -192,8 +192,8 @@ export function refreshAccessToken(
   params: Readonly<RefreshAccessTokenParams>,
 ): (refreshToken: string) => Promise<{
   accessToken: string;
-  expiresIn: number;
-  refreshToken?: string;
+  expiresIn: number | null;
+  refreshToken: string | null;
 }> {
   return async (refreshToken) => {
     const response = await fetch(url, {
@@ -209,7 +209,7 @@ export function refreshAccessToken(
       const parseResult = z
         .object({
           access_token: z.string(),
-          expires_in: z.number(),
+          expires_in: z.number().optional(),
           refresh_token: z.string().optional(),
         })
         .safeParse(responseBody);
@@ -218,10 +218,8 @@ export function refreshAccessToken(
       }
       return {
         accessToken: parseResult.data.access_token,
-        expiresIn: parseResult.data.expires_in,
-        ...(parseResult.data.refresh_token != null
-          ? { refreshToken: parseResult.data.refresh_token }
-          : {}),
+        expiresIn: parseResult.data.expires_in ?? null,
+        refreshToken: parseResult.data.refresh_token ?? null,
       };
     }
     throw new HTTPError(response.status, response.statusText);

--- a/src/scripts/sync-backends/cloud.test.ts
+++ b/src/scripts/sync-backends/cloud.test.ts
@@ -98,6 +98,34 @@ test("createClient (cloud)", async (t) => {
     assert.ok(new Date(persistedToken.expiresAt).getTime() > Date.now());
   });
 
+  await t.test(
+    "replaces the refresh token when the response includes a new one",
+    async () => {
+      const refreshTokens: string[] = [];
+      let refreshCount = 0;
+      const cloud = makeCloud({
+        refreshAccessToken(refreshToken) {
+          refreshTokens.push(refreshToken);
+          refreshCount++;
+          return Promise.resolve({
+            accessToken: `access-${refreshCount + 1}`,
+            expiresIn: -3600,
+            refreshToken: `refresh-${refreshCount + 1}`,
+          });
+        },
+        readFile: () => Promise.resolve({ content: "content" }),
+      });
+      const { hooks, persisted } = makeHooks();
+      const client = createClient(cloud, makeToken(true), hooks);
+      await client.readFile("file1");
+      await client.readFile("file1");
+      assert.deepEqual(refreshTokens, ["refresh-1", "refresh-2"]);
+      assert.equal(persisted.length, 2);
+      assert.equal(persisted[0]?.refreshToken, "refresh-2");
+      assert.equal(persisted[1]?.refreshToken, "refresh-3");
+    },
+  );
+
   await t.test("passes and preserves the pkce flag on refresh", async () => {
     const pkceArgs: (boolean | undefined)[] = [];
     const cloud = makeCloud({

--- a/src/scripts/sync-backends/cloud.test.ts
+++ b/src/scripts/sync-backends/cloud.test.ts
@@ -79,7 +79,11 @@ test("createClient (cloud)", async (t) => {
     const cloud = makeCloud({
       refreshAccessToken(refreshToken) {
         refreshTokens.push(refreshToken);
-        return Promise.resolve({ accessToken: "access-2", expiresIn: 3600 });
+        return Promise.resolve({
+          accessToken: "access-2",
+          expiresIn: 3600,
+          refreshToken: null,
+        });
       },
       readFile(accessToken) {
         accessTokens.push(accessToken);
@@ -95,6 +99,7 @@ test("createClient (cloud)", async (t) => {
     assert.ok(persistedToken);
     assert.equal(persistedToken.accessToken, "access-2");
     assert.equal(persistedToken.refreshToken, "refresh-1");
+    assert.ok(persistedToken.expiresAt);
     assert.ok(new Date(persistedToken.expiresAt).getTime() > Date.now());
   });
 
@@ -126,12 +131,42 @@ test("createClient (cloud)", async (t) => {
     },
   );
 
+  await t.test(
+    "treats the expiry as unknown when the response omits expires_in",
+    async () => {
+      let refreshCount = 0;
+      const cloud = makeCloud({
+        refreshAccessToken() {
+          refreshCount++;
+          return Promise.resolve({
+            accessToken: "access-2",
+            expiresIn: null,
+            refreshToken: null,
+          });
+        },
+        readFile: () => Promise.resolve({ content: "content" }),
+      });
+      const { hooks, persisted } = makeHooks();
+      const client = createClient(cloud, makeToken(true), hooks);
+      await client.readFile("file1");
+      await client.readFile("file1");
+      assert.equal(refreshCount, 1);
+      const [persistedToken] = persisted;
+      assert.ok(persistedToken);
+      assert.equal(persistedToken.expiresAt, undefined);
+    },
+  );
+
   await t.test("passes and preserves the pkce flag on refresh", async () => {
     const pkceArgs: (boolean | undefined)[] = [];
     const cloud = makeCloud({
       refreshAccessToken(_refreshToken, pkce) {
         pkceArgs.push(pkce);
-        return Promise.resolve({ accessToken: "access-2", expiresIn: 3600 });
+        return Promise.resolve({
+          accessToken: "access-2",
+          expiresIn: 3600,
+          refreshToken: null,
+        });
       },
       readFile: () => Promise.resolve({ content: "content" }),
     });
@@ -154,7 +189,11 @@ test("createClient (cloud)", async (t) => {
       let readCount = 0;
       const cloud = makeCloud({
         refreshAccessToken: () =>
-          Promise.resolve({ accessToken: "access-2", expiresIn: 3600 }),
+          Promise.resolve({
+            accessToken: "access-2",
+            expiresIn: 3600,
+            refreshToken: null,
+          }),
         readFile(accessToken) {
           readCount++;
           if (accessToken !== "access-2") {
@@ -177,7 +216,11 @@ test("createClient (cloud)", async (t) => {
     let readCount = 0;
     const cloud = makeCloud({
       refreshAccessToken: () =>
-        Promise.resolve({ accessToken: "access-2", expiresIn: 3600 }),
+        Promise.resolve({
+          accessToken: "access-2",
+          expiresIn: 3600,
+          refreshToken: null,
+        }),
       readFile() {
         readCount++;
         return Promise.reject(new HTTPError(401, "Unauthorized"));

--- a/src/scripts/sync-backends/cloud.test.ts
+++ b/src/scripts/sync-backends/cloud.test.ts
@@ -182,7 +182,7 @@ test("createClient (cloud)", async (t) => {
       assert.equal(refreshCount, 1);
       const [persistedToken] = persisted;
       assert.ok(persistedToken);
-      assert.equal(persistedToken.expiresAt, undefined);
+      assert.equal(persistedToken.expiresAt, null);
     },
   );
 

--- a/src/scripts/sync-backends/cloud.test.ts
+++ b/src/scripts/sync-backends/cloud.test.ts
@@ -73,6 +73,35 @@ test("createClient (cloud)", async (t) => {
     assert.equal(persisted.length, 0);
   });
 
+  await t.test(
+    "refreshes a token that expires within the 60-second margin",
+    async () => {
+      let refreshCount = 0;
+      const cloud = makeCloud({
+        refreshAccessToken() {
+          refreshCount++;
+          return Promise.resolve({
+            accessToken: "access-2",
+            expiresIn: 3600,
+            refreshToken: null,
+          });
+        },
+        readFile: () => Promise.resolve({ content: "content" }),
+      });
+      const { hooks } = makeHooks();
+      const client = createClient(
+        cloud,
+        {
+          ...makeToken(false),
+          expiresAt: new Date(Date.now() + 30_000).toISOString(),
+        },
+        hooks,
+      );
+      await client.readFile("file1");
+      assert.equal(refreshCount, 1);
+    },
+  );
+
   await t.test("refreshes an expired token before the operation", async () => {
     const refreshTokens: string[] = [];
     const accessTokens: string[] = [];

--- a/src/scripts/sync-backends/cloud.ts
+++ b/src/scripts/sync-backends/cloud.ts
@@ -45,7 +45,10 @@ export function createClient(
     }
   };
   const handleRefresh = async <T>(f: () => Promise<T>): Promise<T> => {
-    if (token.expiresAt != null && dayjs().isAfter(dayjs(token.expiresAt))) {
+    if (
+      token.expiresAt != null &&
+      dayjs().isAfter(dayjs(token.expiresAt).subtract(60, "second"))
+    ) {
       await refresh();
     }
     try {

--- a/src/scripts/sync-backends/cloud.ts
+++ b/src/scripts/sync-backends/cloud.ts
@@ -24,6 +24,9 @@ export function createClient(
         ...token,
         accessToken: newToken.accessToken,
         expiresAt: dayjs().add(newToken.expiresIn, "second").toISOString(),
+        ...(newToken.refreshToken != null
+          ? { refreshToken: newToken.refreshToken }
+          : {}),
       };
       await hooks.persistToken(token);
     } catch (e: unknown) {

--- a/src/scripts/sync-backends/cloud.ts
+++ b/src/scripts/sync-backends/cloud.ts
@@ -20,10 +20,17 @@ export function createClient(
         token.refreshToken,
         token.pkce,
       );
+      const { expiresAt: _oldExpiresAt, ...restToken } = token;
       token = {
-        ...token,
+        ...restToken,
         accessToken: newToken.accessToken,
-        expiresAt: dayjs().add(newToken.expiresIn, "second").toISOString(),
+        ...(newToken.expiresIn != null
+          ? {
+              expiresAt: dayjs()
+                .add(newToken.expiresIn, "second")
+                .toISOString(),
+            }
+          : {}),
         ...(newToken.refreshToken != null
           ? { refreshToken: newToken.refreshToken }
           : {}),
@@ -38,7 +45,7 @@ export function createClient(
     }
   };
   const handleRefresh = async <T>(f: () => Promise<T>): Promise<T> => {
-    if (dayjs().isAfter(dayjs(token.expiresAt))) {
+    if (token.expiresAt != null && dayjs().isAfter(dayjs(token.expiresAt))) {
       await refresh();
     }
     try {

--- a/src/scripts/sync-backends/cloud.ts
+++ b/src/scripts/sync-backends/cloud.ts
@@ -20,9 +20,7 @@ export function createClient(
         token.refreshToken,
         token.pkce,
       );
-      const { expiresAt: _oldExpiresAt, ...restToken } = token;
       token = {
-        ...restToken,
         accessToken: newToken.accessToken,
         ...(newToken.expiresIn != null
           ? {
@@ -31,9 +29,8 @@ export function createClient(
                 .toISOString(),
             }
           : {}),
-        ...(newToken.refreshToken != null
-          ? { refreshToken: newToken.refreshToken }
-          : {}),
+        refreshToken: newToken.refreshToken ?? token.refreshToken,
+        pkce: token.pkce ?? false,
       };
       await hooks.persistToken(token);
     } catch (e: unknown) {

--- a/src/scripts/sync-backends/cloud.ts
+++ b/src/scripts/sync-backends/cloud.ts
@@ -22,13 +22,10 @@ export function createClient(
       );
       token = {
         accessToken: newToken.accessToken,
-        ...(newToken.expiresIn != null
-          ? {
-              expiresAt: dayjs()
-                .add(newToken.expiresIn, "second")
-                .toISOString(),
-            }
-          : {}),
+        expiresAt:
+          newToken.expiresIn != null
+            ? dayjs().add(newToken.expiresIn, "second").toISOString()
+            : null,
         refreshToken: newToken.refreshToken ?? token.refreshToken,
         pkce: token.pkce ?? false,
       };


### PR DESCRIPTION
Support refresh token rotation and handle token responses without `expires_in`, so that sync keeps working if Google or Dropbox changes its token endpoint behavior within what RFC 6749 / OAuth 2.1 allows. Also refresh access tokens 60 seconds before expiry to avoid using a token that expires mid-request.