### PR TITLE
Stop tracking developer-local files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Environment files
 .env
+.env.local
 
 # Build outputs
 dist/
@@ -7,19 +8,10 @@ dist/
 # Dependencies
 node_modules/
 
-# Local development
-*.local
-local/
-
 # Untranslated readme files
 README.*.md
 !README.de.md
 !README.zh-CN.md
-
-# Claude Code
-.claude/settings.local.json
-.claude/worktrees/
-CLAUDE.local.md
 
 # Playwright
 test-results/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,0 @@
-{
-  "recommendations": ["oxc.oxc-vscode"]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-  "editor.defaultFormatter": "oxc.oxc-vscode",
-  "editor.formatOnSave": true
-}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,0 @@
-AGENTS.md


### PR DESCRIPTION
.vscode/, .claude/, CLAUDE.md and CLAUDE.local.md are per-developer
artifacts rather than project configuration. Remove them from the index
and drop their entries from .gitignore; each developer excludes them
locally via .git/info/exclude.
