### PR TITLE
Re-evaluate search results when their links are rewritten in place

### DIFF
--- a/.changeset/randomly-caring-dane.md
+++ b/.changeset/randomly-caring-dane.md
@@ -1,0 +1,5 @@
+---
+ublacklist: patch
+---
+
+Fixed an issue where search results were not re-evaluated when another extension or user script rewrote their links in place.

--- a/src/scripts/content-script/filter.ts
+++ b/src/scripts/content-script/filter.ts
@@ -159,6 +159,10 @@ class Filter {
   #resume() {
     this.#observer.observe(document.body, {
       childList: true,
+      attributes: true,
+      // Limited to href because the performance impact of observing more
+      // attributes on mutation-heavy SERPs is unknown
+      attributeFilter: ["href"],
       subtree: true,
     });
   }


### PR DESCRIPTION
Google sometimes serves search result links as relative `/goto?url=` URLs, and a user script can restore the original URLs by rewriting the `href` attributes in place (see #1025). uBlacklist's MutationObserver only watched childList mutations, so such rewrites were never picked up. This change also observes `href` attribute changes so that affected results are re-evaluated.