### PR TITLE
Restrict the final domain label to letters in domainToURL

### DIFF
--- a/.changeset/nationally-joint-duck.md
+++ b/.changeset/nationally-joint-duck.md
@@ -1,0 +1,5 @@
+---
+ublacklist: patch
+---
+
+Fixed an issue where the `domainToURL` command in SERPINFO extracted a bogus domain such as `1.8m` from text like "1.8M followers".

--- a/src/scripts/content-script/commands.ts
+++ b/src/scripts/content-script/commands.ts
@@ -149,7 +149,7 @@ const propertyCommandImpl: PropertyCommandImpl = {
       return null;
     }
     // https://stackoverflow.com/questions/47514123/domain-name-regex-including-idn-characters-c-sharp
-    const m = /(?:[\p{L}\p{N}][\p{L}\p{N}_-]*\.)+[\p{L}\p{N}]{2,}/u.exec(text);
+    const m = /(?:[\p{L}\p{N}][\p{L}\p{N}_-]*\.)+\p{L}{2,}/u.exec(text);
     if (m == null) {
       return null;
     }


### PR DESCRIPTION
Under the Google `/goto` A/B test (related to #1025), the builtin SERPINFO for Google Web falls back to extracting a domain from the displayed domain text with `domainToURL`. When that text contains no domain (e.g. "1.8M followers"), `domainToURL` extracted a bogus domain such as `1.8m`, because the final-label pattern allowed digits. Since no TLD contains digits (RFC 1123 §2.1, RFC 3696 §2, and the current IANA root zone), the final label is now restricted to letters. As a bonus, the real domain now wins over a preceding numeric token, as in "3.5M views · example.com".